### PR TITLE
Set correct default video extra encoder options (H264 or VP8/VP9)

### DIFF
--- a/src/FFmpegVideoEncoder.cs
+++ b/src/FFmpegVideoEncoder.cs
@@ -164,14 +164,18 @@ namespace SIPSorceryMedia.FFmpeg
                     //ffmpeg.av_opt_set(_videoCodecContext->priv_data, "packetization-mode", "0", 0).ThrowExceptionIfError();
                     //ffmpeg.av_opt_set(_pCodecContext->priv_data, "preset", "veryslow", 0);
                     //ffmpeg.av_opt_set(_videoCodecContext->priv_data, "profile-level-id", "42e01f", 0);
+
+                    ffmpeg.av_opt_set(_encoderContext->priv_data, "tune", "zerolatency", 0).ThrowExceptionIfError();
                 }
-                
+                else if ((_codecID == AVCodecID.AV_CODEC_ID_VP8) || (_codecID == AVCodecID.AV_CODEC_ID_VP9))
+                {
+                    ffmpeg.av_opt_set(_encoderContext->priv_data, "quality", "realtime", 0).ThrowExceptionIfError();
+                }
+
                 foreach (var option in _encoderOptions)
                 {
                     ffmpeg.av_opt_set(_encoderContext->priv_data, option.Key, option.Value, 0).ThrowExceptionIfError();
                 }
-
-                ffmpeg.av_opt_set(_encoderContext->priv_data, "tune", "zerolatency", 0).ThrowExceptionIfError();
 
                 ffmpeg.avcodec_open2(_encoderContext, codec, null).ThrowExceptionIfError();
             }


### PR DESCRIPTION
Small PR about default video extra encoder options:

- option "tune"="zerolatency" is not correct in VP8/VP9 context
- equivalent option in VP8/VP9 context is "quality"="realtime"
