### PR TITLE
FFmpegAudioDecoder: use delegate with AVFrame and small code simplifation

### DIFF
--- a/src/FFmpegVideoDecoder.cs
+++ b/src/FFmpegVideoDecoder.cs
@@ -8,10 +8,6 @@ namespace SIPSorceryMedia.FFmpeg
 {
     public class FFmpegVideoDecoder : IDisposable
     {
-        private const int DEFAULT_VIDEO_FRAME_RATE = 30;
-        private const int AUDIO_OUTPUT_SAMPLE_RATE = 8000;
-        private const int MIN_SLEEP_MILLISECONDS = 15;
-
         private ILogger logger = SIPSorcery.LogFactory.CreateLogger<FFmpegVideoDecoder>();
 
         unsafe private AVInputFormat* _inputFormat = null;
@@ -33,7 +29,6 @@ namespace SIPSorceryMedia.FFmpeg
         private bool _isDisposed;
         private Task? _sourceTask;
 
-        //public unsafe delegate void OnFrameDelegate(ref AVFrame frame);
         public delegate void OnFrameDelegate(ref AVFrame frame);
         public event OnFrameDelegate? OnVideoFrame;
 
@@ -93,7 +88,7 @@ namespace SIPSorceryMedia.FFmpeg
 
                 _videoTimebase = ffmpeg.av_q2d(_fmtCtx->streams[_videoStreamIndex]->time_base);
                 _videoAvgFrameRate = ffmpeg.av_q2d(_fmtCtx->streams[_videoStreamIndex]->avg_frame_rate);
-                _maxVideoFrameSpace = (int)(_videoAvgFrameRate > 0 ? 1000 / _videoAvgFrameRate : 1000 / DEFAULT_VIDEO_FRAME_RATE);
+                _maxVideoFrameSpace = (int)(_videoAvgFrameRate > 0 ? 1000 / _videoAvgFrameRate : 1000 / Helper.DEFAULT_VIDEO_FRAME_RATE);
             }
         }
 
@@ -208,7 +203,7 @@ namespace SIPSorceryMedia.FFmpeg
                                     //Console.WriteLine($"Decoded video frame {frame->width}x{frame->height}, ts {frame->best_effort_timestamp}, delta {frame->best_effort_timestamp - prevVidTs}, dpts {dpts}.");
 
                                     int sleep = (int)(dpts * 1000 - DateTime.Now.Subtract(startTime).TotalMilliseconds);
-                                    if (sleep > MIN_SLEEP_MILLISECONDS)
+                                    if (sleep > Helper.MIN_SLEEP_MILLISECONDS)
                                     {
                                         ffmpeg.av_usleep((uint)(Math.Min(_maxVideoFrameSpace, sleep) * 1000));
                                     }

--- a/src/FFmpegVideoEncoder.cs
+++ b/src/FFmpegVideoEncoder.cs
@@ -9,11 +9,7 @@ namespace SIPSorceryMedia.FFmpeg
 {
     public sealed unsafe class FFmpegVideoEncoder : IVideoEncoder, IDisposable
     {
-        private static readonly List<VideoFormat> _supportedFormats = new List<VideoFormat>
-        {
-            new VideoFormat(VideoCodecsEnum.VP8, Helper.VP8_FORMATID),
-            new VideoFormat(VideoCodecsEnum.H264, Helper.H264_FORMATID)
-        };
+        private static readonly List<VideoFormat> _supportedFormats = Helper.GetSupportedVideoFormats();
 
         public List<VideoFormat> SupportedFormats
         {
@@ -63,7 +59,7 @@ namespace SIPSorceryMedia.FFmpeg
             }
 
 #pragma warning disable CS8603
-            return Encode(codecID, sample, width, height, Helper.DEFAULT_FRAME_RATE, false, avPixelFormat);
+            return Encode(codecID, sample, width, height, Helper.DEFAULT_VIDEO_FRAME_RATE, false, avPixelFormat);
 #pragma warning restore
         }
 

--- a/src/FFmpegVideoEndPoint.cs
+++ b/src/FFmpegVideoEndPoint.cs
@@ -10,18 +10,9 @@ namespace SIPSorceryMedia.FFmpeg
 {
     public class FFmpegVideoEndPoint : IVideoSink, IVideoSource, IDisposable
     {
-        private const int VIDEO_SAMPLING_RATE = 90000;
-        private const int DEFAULT_FRAMES_PER_SECOND = 30;
-        private const int VP8_INITIAL_FORMATID = 96;
-        private const int H264_INITIAL_FORMATID = 100;
-
         public ILogger logger = SIPSorcery.LogFactory.CreateLogger<FFmpegVideoEndPoint>();
 
-        public static readonly List<VideoFormat> SupportedFormats = new List<VideoFormat>
-        {
-            new VideoFormat(VideoCodecsEnum.VP8, VP8_INITIAL_FORMATID, VIDEO_SAMPLING_RATE),
-            new VideoFormat(VideoCodecsEnum.H264, H264_INITIAL_FORMATID, VIDEO_SAMPLING_RATE)
-        };
+        public static readonly List<VideoFormat> SupportedFormats = Helper.GetSupportedVideoFormats();
 
         private FFmpegVideoEncoder _ffmpegEncoder;
 
@@ -126,7 +117,7 @@ namespace SIPSorceryMedia.FFmpeg
             {
                 if (OnVideoSourceEncodedSample != null)
                 {
-                    uint fps = (durationMilliseconds > 0) ? 1000 / durationMilliseconds : DEFAULT_FRAMES_PER_SECOND;
+                    uint fps = (durationMilliseconds > 0) ? 1000 / durationMilliseconds : Helper.DEFAULT_VIDEO_FRAME_RATE;
                     if(fps == 0)
                     {
                         fps = 1;
@@ -139,7 +130,7 @@ namespace SIPSorceryMedia.FFmpeg
                     if (encodedBuffer != null)
                     {
                         //Console.WriteLine($"encoded buffer: {encodedBuffer.HexStr()}");
-                        uint durationRtpTS = VIDEO_SAMPLING_RATE / fps;
+                        uint durationRtpTS = Helper.VIDEO_SAMPLING_RATE / fps;
 
                         // Note the event handler can be removed while the encoding is in progress.
                         OnVideoSourceEncodedSample?.Invoke(durationRtpTS, encodedBuffer);

--- a/src/Helper.cs
+++ b/src/Helper.cs
@@ -8,9 +8,28 @@ namespace SIPSorceryMedia.FFmpeg
 {
     static class Helper
     {
+        public const int MIN_SLEEP_MILLISECONDS = 15;
+
         public const int VIDEO_SAMPLING_RATE = 90000;
-        public const int DEFAULT_FRAME_RATE = 30;
+        public const int AUDIO_SAMPLING_RATE = 8000;
+
+        public const int DEFAULT_VIDEO_FRAME_RATE = 30;
+
         public const int VP8_FORMATID = 96;
         public const int H264_FORMATID = 100;
+
+        internal static List<VideoFormat> GetSupportedVideoFormats() => new List<VideoFormat>
+        {
+            new VideoFormat(VideoCodecsEnum.VP8, Helper.VP8_FORMATID, Helper.VIDEO_SAMPLING_RATE),
+            new VideoFormat(VideoCodecsEnum.H264, Helper.H264_FORMATID, Helper.VIDEO_SAMPLING_RATE)
+        };
+
+        internal static List<AudioFormat> GetSupportedAudioFormats() => new List<AudioFormat>
+        {
+            new AudioFormat(SDPWellKnownMediaFormatsEnum.PCMU),
+            new AudioFormat(SDPWellKnownMediaFormatsEnum.PCMA),
+            new AudioFormat(SDPWellKnownMediaFormatsEnum.G722)
+        };
+
     }
 }


### PR DESCRIPTION
Small **PR**:

**FFmpegAudioDecoder**: use delegate with AVFrame (to be coherent with **FFmpeagVideoDecoder**)

**Continue simplification**: centralize constant and supported audio/video formats in **Helper** class