### PR TITLE
Fix and camera manager

### DIFF
--- a/src/FFmpegAudioDecoder.cs
+++ b/src/FFmpegAudioDecoder.cs
@@ -248,6 +248,7 @@ namespace SIPSorceryMedia.FFmpeg
 
                         ffmpeg.avformat_seek_file(_fmtCtx, _audioStreamIndex, 0, 0, _fmtCtx->streams[_audioStreamIndex]->duration, 0).ThrowExceptionIfError();
 
+                        canContinue = true;
                         goto Repeat;
                     }
                     else

--- a/src/FFmpegCameraManager.cs
+++ b/src/FFmpegCameraManager.cs
@@ -1,0 +1,57 @@
+﻿using FFmpeg.AutoGen;
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+using DirectShowLib;
+
+namespace SIPSorceryMedia.FFmpeg
+{
+    public unsafe class FFmpegCameraManager
+    {
+        static public List<String> GetCameraDevices()
+        {
+            List<String> result = new List<string>();
+
+            string inputFormat = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dshow"
+                                    : RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "v4l2"
+                                    : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "avfoundation"
+                                    : throw new NotSupportedException($"Cannot find adequate input format - OSArchitecture:[{RuntimeInformation.OSArchitecture}] - OSDescription:[{RuntimeInformation.OSDescription}]");
+
+            
+            // FFmpeg doesn't implement avdevice_list_input_sources() for the DShow input format yet.
+            if (inputFormat == "dshow")
+            {
+                var dsDevices = DsDevice.GetDevicesOfCat(FilterCategory.VideoInputDevice);
+                for (int i = 0; i < dsDevices.Length; i++)
+                {
+                    var dsDevice = dsDevices[i];
+                    if ( (dsDevice.Name != null) && (dsDevice.Name.Length > 0) )
+                        result.Add(dsDevice.Name);
+                }
+            }
+            else
+            {
+                AVInputFormat* avInputFormat = ffmpeg.av_find_input_format(inputFormat);
+                AVDeviceInfoList* avDeviceInfoList = null;
+                
+                ffmpeg.avdevice_list_input_sources(avInputFormat, null, null, &avDeviceInfoList).ThrowExceptionIfError();
+                int nDevices = avDeviceInfoList->nb_devices;
+                var avDevices = avDeviceInfoList->devices;
+
+                for (int i = 0; i < nDevices; i++)
+                {
+                    var avDevice = avDevices[i];
+                    var name = Marshal.PtrToStringAnsi((IntPtr)avDevice->device_description);
+                    //var path = Marshal.PtrToStringAnsi((IntPtr)avDevice->device_name);
+
+                    if ((name != null) && (name.Length > 0))
+                        result.Add(name);
+                }
+
+                ffmpeg.avdevice_free_list_devices(&avDeviceInfoList);
+            }
+            return result;
+        }
+    }
+}

--- a/src/FFmpegVideoDecoder.cs
+++ b/src/FFmpegVideoDecoder.cs
@@ -8,10 +8,6 @@ namespace SIPSorceryMedia.FFmpeg
 {
     public class FFmpegVideoDecoder : IDisposable
     {
-        private const int DEFAULT_VIDEO_FRAME_RATE = 30;
-        private const int AUDIO_OUTPUT_SAMPLE_RATE = 8000;
-        private const int MIN_SLEEP_MILLISECONDS = 15;
-
         private ILogger logger = SIPSorcery.LogFactory.CreateLogger<FFmpegVideoDecoder>();
 
         unsafe private AVInputFormat* _inputFormat = null;
@@ -33,7 +29,6 @@ namespace SIPSorceryMedia.FFmpeg
         private bool _isDisposed;
         private Task? _sourceTask;
 
-        //public unsafe delegate void OnFrameDelegate(ref AVFrame frame);
         public delegate void OnFrameDelegate(ref AVFrame frame);
         public event OnFrameDelegate? OnVideoFrame;
 
@@ -93,7 +88,7 @@ namespace SIPSorceryMedia.FFmpeg
 
                 _videoTimebase = ffmpeg.av_q2d(_fmtCtx->streams[_videoStreamIndex]->time_base);
                 _videoAvgFrameRate = ffmpeg.av_q2d(_fmtCtx->streams[_videoStreamIndex]->avg_frame_rate);
-                _maxVideoFrameSpace = (int)(_videoAvgFrameRate > 0 ? 1000 / _videoAvgFrameRate : 1000 / DEFAULT_VIDEO_FRAME_RATE);
+                _maxVideoFrameSpace = (int)(_videoAvgFrameRate > 0 ? 1000 / _videoAvgFrameRate : 1000 / Helper.DEFAULT_VIDEO_FRAME_RATE);
             }
         }
 
@@ -208,7 +203,7 @@ namespace SIPSorceryMedia.FFmpeg
                                     //Console.WriteLine($"Decoded video frame {frame->width}x{frame->height}, ts {frame->best_effort_timestamp}, delta {frame->best_effort_timestamp - prevVidTs}, dpts {dpts}.");
 
                                     int sleep = (int)(dpts * 1000 - DateTime.Now.Subtract(startTime).TotalMilliseconds);
-                                    if (sleep > MIN_SLEEP_MILLISECONDS)
+                                    if (sleep > Helper.MIN_SLEEP_MILLISECONDS)
                                     {
                                         ffmpeg.av_usleep((uint)(Math.Min(_maxVideoFrameSpace, sleep) * 1000));
                                     }

--- a/src/FFmpegVideoDecoder.cs
+++ b/src/FFmpegVideoDecoder.cs
@@ -77,7 +77,7 @@ namespace SIPSorceryMedia.FFmpeg
                 // Set up video decoder.
                 AVCodec* vidCodec = null;
                 _videoStreamIndex = ffmpeg.av_find_best_stream(_fmtCtx, AVMediaType.AVMEDIA_TYPE_VIDEO, -1, -1, &vidCodec, 0).ThrowExceptionIfError();
-                logger.LogDebug($"FFmpeg file source decoder {ffmpeg.avcodec_get_name(vidCodec->id)} video codec for stream {_videoStreamIndex}.");
+                logger.LogDebug($"FFmpeg file source decoder [{ffmpeg.avcodec_get_name(vidCodec->id)}] video codec for stream [{_videoStreamIndex}] - url:[{_sourceUrl}].");
                 _vidDecCtx = ffmpeg.avcodec_alloc_context3(vidCodec);
                 if (_vidDecCtx == null)
                 {
@@ -238,6 +238,8 @@ namespace SIPSorceryMedia.FFmpeg
                         ((int)ffmpeg.avio_seek(_fmtCtx->pb, 0, ffmpeg.AVIO_SEEKABLE_NORMAL)).ThrowExceptionIfError();
 
                         ffmpeg.avformat_seek_file(_fmtCtx, _videoStreamIndex, 0, 0, _fmtCtx->streams[_videoStreamIndex]->duration, 0).ThrowExceptionIfError();
+
+                        canContinue = true;
 
                         goto Repeat;
                     }

--- a/src/FFmpegVideoEncoder.cs
+++ b/src/FFmpegVideoEncoder.cs
@@ -9,11 +9,7 @@ namespace SIPSorceryMedia.FFmpeg
 {
     public sealed unsafe class FFmpegVideoEncoder : IVideoEncoder, IDisposable
     {
-        private static readonly List<VideoFormat> _supportedFormats = new List<VideoFormat>
-        {
-            new VideoFormat(VideoCodecsEnum.VP8, Helper.VP8_FORMATID),
-            new VideoFormat(VideoCodecsEnum.H264, Helper.H264_FORMATID)
-        };
+        private static readonly List<VideoFormat> _supportedFormats = Helper.GetSupportedVideoFormats();
 
         public List<VideoFormat> SupportedFormats
         {
@@ -63,7 +59,7 @@ namespace SIPSorceryMedia.FFmpeg
             }
 
 #pragma warning disable CS8603
-            return Encode(codecID, sample, width, height, Helper.DEFAULT_FRAME_RATE, false, avPixelFormat);
+            return Encode(codecID, sample, width, height, Helper.DEFAULT_VIDEO_FRAME_RATE, false, avPixelFormat);
 #pragma warning restore
         }
 

--- a/src/FFmpegVideoEncoder.cs
+++ b/src/FFmpegVideoEncoder.cs
@@ -171,6 +171,10 @@ namespace SIPSorceryMedia.FFmpeg
 
                 
                 ffmpeg.avcodec_open2(_encoderContext, codec, null).ThrowExceptionIfError();
+
+
+                logger.LogDebug($"Successfully initialised ffmpeg based image encoder: CodecId:[{codecID}] - {width}:{height} - {fps} Fps");
+
             }
         }
 
@@ -284,6 +288,11 @@ namespace SIPSorceryMedia.FFmpeg
                     if (!_isEncoderInitialised)
                     {
                         InitialiseEncoder(codecID, width, height, fps);
+                    }
+                    else if (_encoderContext->width != width || _encoderContext->height != height)
+                    {
+                        _encoderContext->width = width;
+                        _encoderContext->height = height;
                     }
 
                     int _linesizeY = width;

--- a/src/FFmpegVideoEndPoint.cs
+++ b/src/FFmpegVideoEndPoint.cs
@@ -10,18 +10,9 @@ namespace SIPSorceryMedia.FFmpeg
 {
     public class FFmpegVideoEndPoint : IVideoSink, IVideoSource, IDisposable
     {
-        private const int VIDEO_SAMPLING_RATE = 90000;
-        private const int DEFAULT_FRAMES_PER_SECOND = 30;
-        private const int VP8_INITIAL_FORMATID = 96;
-        private const int H264_INITIAL_FORMATID = 100;
-
         public ILogger logger = SIPSorcery.LogFactory.CreateLogger<FFmpegVideoEndPoint>();
 
-        public static readonly List<VideoFormat> SupportedFormats = new List<VideoFormat>
-        {
-            new VideoFormat(VideoCodecsEnum.VP8, VP8_INITIAL_FORMATID, VIDEO_SAMPLING_RATE),
-            new VideoFormat(VideoCodecsEnum.H264, H264_INITIAL_FORMATID, VIDEO_SAMPLING_RATE)
-        };
+        public static readonly List<VideoFormat> SupportedFormats = Helper.GetSupportedVideoFormats();
 
         private FFmpegVideoEncoder _ffmpegEncoder;
 
@@ -126,7 +117,7 @@ namespace SIPSorceryMedia.FFmpeg
             {
                 if (OnVideoSourceEncodedSample != null)
                 {
-                    uint fps = (durationMilliseconds > 0) ? 1000 / durationMilliseconds : DEFAULT_FRAMES_PER_SECOND;
+                    uint fps = (durationMilliseconds > 0) ? 1000 / durationMilliseconds : Helper.DEFAULT_VIDEO_FRAME_RATE;
                     if(fps == 0)
                     {
                         fps = 1;
@@ -139,7 +130,7 @@ namespace SIPSorceryMedia.FFmpeg
                     if (encodedBuffer != null)
                     {
                         //Console.WriteLine($"encoded buffer: {encodedBuffer.HexStr()}");
-                        uint durationRtpTS = VIDEO_SAMPLING_RATE / fps;
+                        uint durationRtpTS = Helper.VIDEO_SAMPLING_RATE / fps;
 
                         // Note the event handler can be removed while the encoding is in progress.
                         OnVideoSourceEncodedSample?.Invoke(durationRtpTS, encodedBuffer);

--- a/src/Helper.cs
+++ b/src/Helper.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace SIPSorceryMedia.FFmpeg
 {
-    static class Helper
+    public class Helper
     {
         public const int MIN_SLEEP_MILLISECONDS = 15;
 

--- a/src/Helper.cs
+++ b/src/Helper.cs
@@ -8,9 +8,28 @@ namespace SIPSorceryMedia.FFmpeg
 {
     static class Helper
     {
+        public const int MIN_SLEEP_MILLISECONDS = 15;
+
         public const int VIDEO_SAMPLING_RATE = 90000;
-        public const int DEFAULT_FRAME_RATE = 30;
+        public const int AUDIO_SAMPLING_RATE = 8000;
+
+        public const int DEFAULT_VIDEO_FRAME_RATE = 30;
+
         public const int VP8_FORMATID = 96;
         public const int H264_FORMATID = 100;
+
+        internal static List<VideoFormat> GetSupportedVideoFormats() => new List<VideoFormat>
+        {
+            new VideoFormat(VideoCodecsEnum.VP8, Helper.VP8_FORMATID, Helper.VIDEO_SAMPLING_RATE),
+            new VideoFormat(VideoCodecsEnum.H264, Helper.H264_FORMATID, Helper.VIDEO_SAMPLING_RATE)
+        };
+
+        internal static List<AudioFormat> GetSupportedAudioFormats() => new List<AudioFormat>
+        {
+            new AudioFormat(SDPWellKnownMediaFormatsEnum.PCMU),
+            new AudioFormat(SDPWellKnownMediaFormatsEnum.PCMA),
+            new AudioFormat(SDPWellKnownMediaFormatsEnum.G722)
+        };
+
     }
 }

--- a/src/SIPSorceryMedia.FFmpeg.csproj
+++ b/src/SIPSorceryMedia.FFmpeg.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,6 +20,7 @@
   </ItemGroup>
   
   <ItemGroup>
+    <PackageReference Include="DirectShowLib.Standard" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="SIPSorceryMedia.Abstractions" Version="1.1.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />

--- a/src/SIPSorceryMedia.FFmpeg.csproj
+++ b/src/SIPSorceryMedia.FFmpeg.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/SIPSorceryMedia.FFmpeg.sln
+++ b/src/SIPSorceryMedia.FFmpeg.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30320.27
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31919.166
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SIPSorceryMedia.FFmpeg", "SIPSorceryMedia.FFmpeg.csproj", "{C3721569-24C0-4666-994F-6B042E84A786}"
 EndProject
@@ -14,6 +14,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FFmpegMp4Test", "..\test\FFmpegMp4Test\FFmpegMp4Test.csproj", "{7258807E-BB24-42C9-8EC6-098D54224EA9}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FFmpegFileAndDevicesTest", "..\test\FFmpegFileAndDevicesTest\FFmpegFileAndDevicesTest.csproj", "{981BFE56-79B9-4D6D-878E-029502904E94}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FFmpegWebRTCReceiver", "..\test\FFmpegWebRtcReceiver\FFmpegWebRTCReceiver.csproj", "{21D27EF1-C666-4A5D-8B12-4F4E5CFAEA9B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -84,6 +86,18 @@ Global
 		{981BFE56-79B9-4D6D-878E-029502904E94}.Release|x64.Build.0 = Release|Any CPU
 		{981BFE56-79B9-4D6D-878E-029502904E94}.Release|x86.ActiveCfg = Release|Any CPU
 		{981BFE56-79B9-4D6D-878E-029502904E94}.Release|x86.Build.0 = Release|Any CPU
+		{21D27EF1-C666-4A5D-8B12-4F4E5CFAEA9B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{21D27EF1-C666-4A5D-8B12-4F4E5CFAEA9B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{21D27EF1-C666-4A5D-8B12-4F4E5CFAEA9B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{21D27EF1-C666-4A5D-8B12-4F4E5CFAEA9B}.Debug|x64.Build.0 = Debug|Any CPU
+		{21D27EF1-C666-4A5D-8B12-4F4E5CFAEA9B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{21D27EF1-C666-4A5D-8B12-4F4E5CFAEA9B}.Debug|x86.Build.0 = Debug|Any CPU
+		{21D27EF1-C666-4A5D-8B12-4F4E5CFAEA9B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{21D27EF1-C666-4A5D-8B12-4F4E5CFAEA9B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{21D27EF1-C666-4A5D-8B12-4F4E5CFAEA9B}.Release|x64.ActiveCfg = Release|Any CPU
+		{21D27EF1-C666-4A5D-8B12-4F4E5CFAEA9B}.Release|x64.Build.0 = Release|Any CPU
+		{21D27EF1-C666-4A5D-8B12-4F4E5CFAEA9B}.Release|x86.ActiveCfg = Release|Any CPU
+		{21D27EF1-C666-4A5D-8B12-4F4E5CFAEA9B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -93,6 +107,7 @@ Global
 		{5D877D45-557E-4E23-9453-85E8B88C10EB} = {C76D54C9-D8F7-4D5E-B82A-35887626EC04}
 		{7258807E-BB24-42C9-8EC6-098D54224EA9} = {C76D54C9-D8F7-4D5E-B82A-35887626EC04}
 		{981BFE56-79B9-4D6D-878E-029502904E94} = {C76D54C9-D8F7-4D5E-B82A-35887626EC04}
+		{21D27EF1-C666-4A5D-8B12-4F4E5CFAEA9B} = {C76D54C9-D8F7-4D5E-B82A-35887626EC04}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8476DD5B-15BB-4770-A727-42C54B0648F8}

--- a/src/VideoFrameConverter.cs
+++ b/src/VideoFrameConverter.cs
@@ -8,7 +8,7 @@ namespace SIPSorceryMedia.FFmpeg
 {
     public sealed unsafe class VideoFrameConverter : IDisposable
     {
-        private static ILogger logger = NullLogger.Instance;
+        private static ILogger logger = SIPSorcery.LogFactory.CreateLogger<VideoFrameConverter>();
 
         private readonly IntPtr _convertedFrameBufferPtr;
         private readonly int _srcWidth;
@@ -116,6 +116,7 @@ namespace SIPSorceryMedia.FFmpeg
             };
         }
 
+        // to convert Bitmap to Frame
         public byte[] ConvertToBuffer(byte[] srcData)
         {
             //int linesz0 = ffmpeg.av_image_get_linesize(_srcPixelFormat, _dstSize.Width, 0);

--- a/test/FFmpegEncodingTest/FFmpegEncodingTest.csproj
+++ b/test/FFmpegEncodingTest/FFmpegEncodingTest.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
-    <PackageReference Include="SIPSorcery" Version="4.0.76-pre" />
+    <PackageReference Include="SIPSorcery" Version="6.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/FFmpegEncodingTest/Program.cs
+++ b/test/FFmpegEncodingTest/Program.cs
@@ -11,6 +11,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using FFmpeg.AutoGen;
 using SIPSorcery.Net;
+using SIPSorceryMedia.Abstractions;
 using SIPSorceryMedia.FFmpeg;
 
 namespace FFmpegEncodingTest
@@ -173,19 +174,12 @@ namespace FFmpegEncodingTest
 
         private void StreamToFFPlay()
         {
-            var videoCapabilities = new List<SDPMediaFormat>
+            var videoCapabilities = new List<SDPAudioVideoMediaFormat>
                 {
-                    //new SDPMediaFormat(SDPMediaFormatsEnum.VP8)
-                    new SDPMediaFormat(SDPMediaFormatsEnum.H264)
-                    {
-                        FormatID = "96"
-                    }
-                    //new SDPMediaFormat(SDPMediaFormatsEnum.H264)
-                    //{
-                    //    FormatParameterAttribute = $"packetization-mode=1",
-                    //}
+                    new SDPAudioVideoMediaFormat(new VideoFormat(VideoCodecsEnum.H264, Helper.H264_FORMATID, Helper.VIDEO_SAMPLING_RATE))
+                    
                 };
-            int payloadID = Convert.ToInt32(videoCapabilities.First().FormatID);
+            int payloadID = Convert.ToInt32(videoCapabilities.First().ID);
 
             var rtpSession = CreateRtpSession(videoCapabilities);
             //OnTestPatternSampleReady += (media, duration, payload) => rtpSession.SendVp8Frame(duration, payloadID, payload);
@@ -214,7 +208,7 @@ namespace FFmpegEncodingTest
                 AVPixelFormat.AV_PIX_FMT_YUV420P);
         }
 
-        private static RTPSession CreateRtpSession(List<SDPMediaFormat> videoFormats)
+        private static RTPSession CreateRtpSession(List<SDPAudioVideoMediaFormat> videoFormats)
         {
             var rtpSession = new RTPSession(false, false, false, IPAddress.Loopback);
 

--- a/test/FFmpegFileAndDevicesTest/FFmpegFileAndDevicesTest.csproj
+++ b/test/FFmpegFileAndDevicesTest/FFmpegFileAndDevicesTest.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
-    <PackageReference Include="SIPSorcery" Version="5.3.0-pre" />
+    <PackageReference Include="SIPSorcery" Version="6.0.4" />
     <PackageReference Include="SIPSorcery.WebSocketSharp" Version="0.0.1" />
   </ItemGroup>
 

--- a/test/FFmpegWebRtcReceiver/FFmpegWebRTCReceiver.csproj
+++ b/test/FFmpegWebRtcReceiver/FFmpegWebRTCReceiver.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <DisableWinExeOutputInference>true</DisableWinExeOutputInference>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="SIPSorcery" Version="6.0.4" />
+    <PackageReference Include="SIPSorcery.WebSocketSharp" Version="0.0.1" />
+    <PackageReference Include="SIPSorceryMedia.Encoders" Version="0.0.10-pre" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SIPSorceryMedia.FFmpeg.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/FFmpegWebRtcReceiver/Program.cs
+++ b/test/FFmpegWebRtcReceiver/Program.cs
@@ -1,0 +1,231 @@
+﻿//-----------------------------------------------------------------------------
+// Filename: Program.cs
+//
+// Description: Displays a VP8 video stream received from a WebRTC peer.
+//
+// Author(s):
+// Aaron Clauson (aaron@sipsorcery.com)
+// 
+// History:
+// 05 Feb 2020	Aaron Clauson	Created, Dublin, Ireland.
+//
+// License: 
+// BSD 3-Clause "New" or "Revised" License, see included LICENSE.md file.
+//-----------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using CommandLine;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Serilog;
+using Serilog.Extensions.Logging;
+using SIPSorcery.Media;
+using SIPSorcery.Net;
+using SIPSorceryMedia.Abstractions;
+using SIPSorceryMedia.Encoders;
+using SIPSorceryMedia.FFmpeg;
+using WebSocketSharp.Server;
+
+namespace demo
+{
+    public class Options
+    {
+        [Option("cert", Required = false,
+            HelpText = "Path to a `.pfx` certificate archive for the web socket server listener. Format \"--cert=mycertificate.pfx.")]
+        public string WSSCertificate { get; set; }
+
+        [Option("ipv6", Required = false,
+            HelpText = "If set the web socket server will listen on IPv6 instead of IPv4.")]
+        public bool UseIPv6 { get; set; }
+
+        [Option("noaudio", Required = false,
+           HelpText = "If set the an audio track will not be included in the SDP offer.")]
+        public bool NoAudio { get; set; }
+    }
+
+    class Program
+    {
+        private const string STUN_URL = "stun:stun.sipsorcery.com";
+        private const int WEBSOCKET_PORT = 8081;
+        private const int VIDEO_INITIAL_WIDTH = 640;
+        private const int VIDEO_INITIAL_HEIGHT = 480;
+
+        private static Form _form;
+        private static PictureBox _picBox;
+        private static Options _options;
+
+        private static Microsoft.Extensions.Logging.ILogger logger = NullLogger.Instance;
+
+        static void Main(string[] args)
+        {
+            Console.WriteLine("WebRTC Receive Demo");
+
+            logger = AddConsoleLogger();
+
+            var parseResult = Parser.Default.ParseArguments<Options>(args);
+            _options = (parseResult as Parsed<Options>)?.Value;
+            X509Certificate2 wssCertificate = (_options.WSSCertificate != null) ? LoadCertificate(_options.WSSCertificate) : null;
+
+            // Start web socket.
+            Console.WriteLine("Starting web socket server...");
+            var webSocketServer = new WebSocketServer((_options.UseIPv6) ? IPAddress.IPv6Any : IPAddress.Any, WEBSOCKET_PORT, wssCertificate != null);
+            if (webSocketServer.IsSecure)
+            {
+                webSocketServer.SslConfiguration.ServerCertificate = wssCertificate;
+                webSocketServer.SslConfiguration.CheckCertificateRevocation = false;
+                webSocketServer.SslConfiguration.EnabledSslProtocols = System.Security.Authentication.SslProtocols.Tls12;
+            }
+            webSocketServer.AddWebSocketService<WebRTCWebSocketPeer>("/", (peer) => peer.CreatePeerConnection = CreatePeerConnection);
+            webSocketServer.Start();
+
+            Console.WriteLine($"Waiting for web socket connections on {(webSocketServer.IsSecure ? "wss" : "ws")}://{webSocketServer.Address}:{webSocketServer.Port}...");
+
+            // Open a Window to display the video feed from the WebRTC peer.
+            _form = new Form();
+            _form.AutoSize = true;
+            _form.BackgroundImageLayout = ImageLayout.Center;
+            _picBox = new PictureBox
+            {
+                Size = new Size(VIDEO_INITIAL_WIDTH, VIDEO_INITIAL_HEIGHT),
+                Location = new Point(0, 0),
+                Visible = true
+            };
+            _form.Controls.Add(_picBox);
+
+            Application.EnableVisualStyles();
+            Application.Run(_form);
+        }
+
+        private static Task<RTCPeerConnection> CreatePeerConnection()
+        {
+            var videoEP = new SIPSorceryMedia.FFmpeg.FFmpegVideoEndPoint();
+            videoEP.RestrictFormats(format => format.Codec == VideoCodecsEnum.H264);
+
+            videoEP.OnVideoSinkDecodedSample += (byte[] bmp, uint width, uint height, int stride, VideoPixelFormatsEnum pixelFormat) =>
+            {
+                _form.BeginInvoke(new Action(() =>
+                {
+                    unsafe
+                    {
+                        if(_picBox.Width != (int)width || _picBox.Height != (int)height)
+                        {
+                           logger.LogDebug($"Adjusting video display from {_picBox.Width}x{_picBox.Height} to {width}x{height}.");
+                            _picBox.Width = (int)width;
+                            _picBox.Height = (int)height;
+                        }
+
+                        fixed (byte* s = bmp)
+                        {
+                            Bitmap bmpImage = new Bitmap((int)width, (int)height, (int)(bmp.Length / height), PixelFormat.Format24bppRgb, (IntPtr)s);
+                            _picBox.Image = bmpImage;
+                        }
+                    }
+                }));
+            };
+
+            RTCConfiguration config = new RTCConfiguration
+            {
+                //iceServers = new List<RTCIceServer> { new RTCIceServer { urls = STUN_URL } }
+                 X_UseRtpFeedbackProfile = true
+            };
+            var pc = new RTCPeerConnection(config);
+
+            // Add local receive only tracks. This ensures that the SDP answer includes only the codecs we support.
+            if (!_options.NoAudio)
+            {
+
+                MediaStreamTrack audioTrack = new MediaStreamTrack(SDPMediaTypesEnum.audio, false,
+                    new List<SDPAudioVideoMediaFormat> { new SDPAudioVideoMediaFormat(SDPWellKnownMediaFormatsEnum.PCMU) }, MediaStreamStatusEnum.RecvOnly);
+                pc.addTrack(audioTrack);
+
+                pc.OnRtpPacketReceived += Pc_OnRtpPacketReceived;
+
+            }
+            MediaStreamTrack videoTrack = new MediaStreamTrack(videoEP.GetVideoSinkFormats(), MediaStreamStatusEnum.RecvOnly);
+            //MediaStreamTrack videoTrack = new MediaStreamTrack(new VideoFormat(96, "VP8", 90000, "x-google-max-bitrate=5000000"), MediaStreamStatusEnum.RecvOnly);
+            pc.addTrack(videoTrack);
+
+            pc.OnVideoFrameReceived += videoEP.GotVideoFrame;
+            pc.OnVideoFormatsNegotiated += (formats) => videoEP.SetVideoSinkFormat(formats.First());
+
+
+            pc.onconnectionstatechange += async (state) =>
+            {
+                logger.LogDebug($"Peer connection state change to {state}.");
+
+                if (state == RTCPeerConnectionState.failed)
+                {
+                    pc.Close("ice disconnection");
+                }
+                else if (state == RTCPeerConnectionState.closed)
+                {
+                    await videoEP.CloseVideo();
+                }
+                else if (state == RTCPeerConnectionState.connected)
+                {
+                    await videoEP.StartVideoSink();
+                }
+            };
+
+            // Diagnostics.
+            //pc.OnReceiveReport += (re, media, rr) => logger.LogDebug($"RTCP Receive for {media} from {re}\n{rr.GetDebugSummary()}");
+            pc.OnSendReport += (media, sr) => logger.LogDebug($"RTCP Send for {media}\n{sr.GetDebugSummary()}");
+            //pc.GetRtpChannel().OnStunMessageReceived += (msg, ep, isRelay) => logger.LogDebug($"RECV STUN {msg.Header.MessageType} (txid: {msg.Header.TransactionId.HexStr()}) from {ep}.");
+            //pc.GetRtpChannel().OnStunMessageSent += (msg, ep, isRelay) => logger.LogDebug($"SEND STUN {msg.Header.MessageType} (txid: {msg.Header.TransactionId.HexStr()}) to {ep}.");
+            pc.oniceconnectionstatechange += (state) => logger.LogDebug($"ICE connection state change to {state}.");
+
+            return Task.FromResult(pc);
+        }
+
+        private static void Pc_OnRtpPacketReceived(IPEndPoint remoteEndPoint, SDPMediaTypesEnum mediaType, RTPPacket rtpPacket)
+        {
+            
+        }
+
+        private static X509Certificate2 LoadCertificate(string path)
+        {
+            if (!File.Exists(path))
+            {
+                logger.LogWarning($"No certificate file could be found at {path}.");
+                return null;
+            }
+            else
+            {
+                X509Certificate2 cert = new X509Certificate2(path, "", X509KeyStorageFlags.Exportable);
+                if (cert == null)
+                {
+                    logger.LogWarning($"Failed to load X509 certificate from file {path}.");
+                }
+                else
+                {
+                    logger.LogInformation($"Certificate file successfully loaded {cert.Subject}, thumbprint {cert.Thumbprint}, has private key {cert.HasPrivateKey}.");
+                }
+                return cert;
+            }
+        }
+
+        /// <summary>
+        /// Adds a console logger. Can be omitted if internal SIPSorcery debug and warning messages are not required.
+        /// </summary>
+        private static Microsoft.Extensions.Logging.ILogger AddConsoleLogger()
+        {
+            var serilogLogger = new LoggerConfiguration()
+                .Enrich.FromLogContext()
+                .MinimumLevel.Is(Serilog.Events.LogEventLevel.Debug)
+                .WriteTo.Console()
+                .CreateLogger();
+            var factory = new SerilogLoggerFactory(serilogLogger);
+            SIPSorcery.LogFactory.Set(factory);
+            return factory.CreateLogger<Program>();
+        }
+    }
+}

--- a/test/FFmpegWebRtcReceiver/capture.html
+++ b/test/FFmpegWebRtcReceiver/capture.html
@@ -1,0 +1,69 @@
+﻿<!DOCTYPE html>
+<head>
+    <meta charset="UTF-8">
+
+    <script type="text/javascript">
+
+        const STUN_URL = "stun:stun.sipsorcery.com";
+        const WEBSOCKET_URL = "ws://127.0.0.1:8081/"
+
+        var pc, ws;
+
+        async function start() {
+
+            // Request access to required audio/video capture devices.
+            var captureStm = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+            document.querySelector('#videoCtl').srcObject = captureStm; // No remote streams so render local ones.
+
+            pc = new RTCPeerConnection({ iceServers: [{ urls: STUN_URL }] });
+
+            //pc.ontrack = evt => document.querySelector('#videoCtl').srcObject = evt.streams[0];
+            pc.onicecandidate = evt => evt.candidate && ws.send(JSON.stringify(evt.candidate));
+
+            // Diagnostics.
+            pc.onicegatheringstatechange = () => console.log("onicegatheringstatechange: " + pc.iceGatheringState);
+            pc.oniceconnectionstatechange = () => console.log("oniceconnectionstatechange: " + pc.iceConnectionState);
+            pc.onsignalingstatechange = () => console.log("onsignalingstatechange: " + pc.signalingState);
+            pc.onconnectionstatechange = () => console.log("onconnectionstatechange: " + pc.connectionState);
+
+            // Add local capture streams to peer connection.
+            captureStm.getTracks().forEach(track => pc.addTrack(track, captureStm));
+
+            // Web socket signaling.
+            ws = new WebSocket(document.querySelector('#websockurl').value, []);
+            ws.onmessage = async function (evt) {
+                if (/^[\{"'\s]*candidate/.test(evt.data)) {
+                    pc.addIceCandidate(JSON.parse(evt.data));
+                }
+                else {
+                    await pc.setRemoteDescription(new RTCSessionDescription(JSON.parse(evt.data)));
+                    pc.createAnswer()
+                        .then((answer) => pc.setLocalDescription(answer))
+                        .then(() => ws.send(JSON.stringify(pc.localDescription)));
+                }
+            };
+        };
+
+        async function closePeer() {
+            pc.getSenders().forEach(sender => {
+                sender.track.stop();
+                pc.removeTrack(sender);
+            });
+            await pc.close();
+            await ws.close();
+        };
+
+    </script>
+</head>
+<body>
+    <video controls autoplay="autoplay" id="videoCtl" width="640" height="480"></video>
+    <div>
+        <input type="text" id="websockurl" size="40" />
+        <button type="button" class="btn btn-success" onclick="start();">Start</button>
+        <button type="button" class="btn btn-success" onclick="closePeer();">Close</button>
+    </div>
+</body>
+
+<script>
+    document.querySelector('#websockurl').value = WEBSOCKET_URL;
+</script>

--- a/test/FFmpegWebRtcReceiver/captureopts.html
+++ b/test/FFmpegWebRtcReceiver/captureopts.html
@@ -1,0 +1,147 @@
+﻿<!DOCTYPE html>
+<head>
+    <meta charset="UTF-8">
+
+    <script type="text/javascript">
+
+        const STUN_URL = "stun:stun.sipsorcery.com";
+        const WEBSOCKET_URL = "ws://127.0.0.1:8081/";
+        const FRAME_RATE = 30.0;
+
+        var pc, ws, statsInterval, videoSender;
+        var lastBytesSent = 0, lastTimestamp = 0;
+
+        async function start() {
+
+            // Construct the audio and video capture options from the HTML inputs.
+            let videoResFn = function (videoResStr) {
+                switch (videoResStr) {
+                    case "default": return true;
+                    case "240p": return { width: 320, height: 240, frameRate: FRAME_RATE};
+                    case "480p": return { width: 640, height: 480, frameRate: FRAME_RATE};
+                    case "720p": return { width: 1280, height: 720, frameRate: FRAME_RATE};
+                    case "1080p": return { width: 1920, height: 1080, frameRate: FRAME_RATE};
+                    default: return { };
+                }
+            };
+
+            let captureOptions = {
+                audio: document.querySelector('input[name="captureAudio"]').checked,
+                video:
+                    document.querySelector('input[name="captureVideo"]').checked ?
+                        videoResFn(document.querySelector('input[name="videoResolution"]:checked').value) : false
+            };
+
+            console.log(document.querySelector('input[name="videoResolution"]:checked').value);
+            console.log(captureOptions);
+
+            // Request access to required audio/video capture devices.
+            let captureStm = await navigator.mediaDevices.getUserMedia(captureOptions);
+            document.querySelector('#videoCtl').srcObject = captureStm; // No remote streams so render local ones.
+
+            pc = new RTCPeerConnection({ iceServers: [{ urls: STUN_URL }] });
+
+            statsInterval = window.setInterval(getConnectionStats, 1000);
+
+            pc.onicecandidate = evt => evt.candidate && ws.send(JSON.stringify(evt.candidate));
+
+            // Diagnostics.
+            pc.onicegatheringstatechange = () => console.log("onicegatheringstatechange: " + pc.iceGatheringState);
+            pc.oniceconnectionstatechange = () => console.log("oniceconnectionstatechange: " + pc.iceConnectionState);
+            pc.onsignalingstatechange = () => console.log("onsignalingstatechange: " + pc.signalingState);
+            pc.onconnectionstatechange = () => console.log("onconnectionstatechange: " + pc.connectionState);
+
+            // Add local capture streams to peer connection.
+            captureStm.getTracks().forEach(track => pc.addTrack(track, captureStm));
+
+            // Web socket signaling.
+            ws = new WebSocket(document.querySelector('#websockurl').value, []);
+            ws.onmessage = async function (evt) {
+                if (/^[\{"'\s]*candidate/.test(evt.data)) {
+                    pc.addIceCandidate(JSON.parse(evt.data));
+                }
+                else {
+                    console.log(`Remote Offer: ${JSON.parse(evt.data).sdp}`);
+                    await pc.setRemoteDescription(new RTCSessionDescription(JSON.parse(evt.data)));
+                    pc.createAnswer()
+                        .then(answer => pc.setLocalDescription(answer))
+                        .then(() => {
+                            console.log(`Local Answer: ${pc.localDescription.sdp}`);
+                            ws.send(JSON.stringify(pc.localDescription));
+                        });
+                }
+            };
+        };
+
+        async function closePeer() {
+            document.querySelector('#videoCtl').srcObject.getTracks().forEach(function (track) {
+                track.stop();
+            });
+            pc.getSenders().forEach(sender => {
+                sender.track.stop();
+                pc.removeTrack(sender);
+            });
+            await pc.close();
+            await ws.close();
+            clearInterval(statsInterval);
+        };
+
+        function getConnectionStats() {
+
+            pc.getSenders().forEach(sender => {
+
+                sender.getStats().then(stats => {
+                    stats.forEach(report => {
+                        if (report.type === "outbound-rtp" && report.kind === "video") {
+                            let timestamp = report["timestamp"];
+                            let bytesSent = report["bytesSent"];
+
+                            let bw = ((bytesSent - lastBytesSent) * 8) / ((timestamp - lastTimestamp) / 1000)
+
+                            document.querySelector("#videoBandwidth").innerText = bw.toFixed(0);
+
+                            document.querySelector("#qualityLimitationReason").innerText = report["qualityLimitationReason"];
+                            document.querySelector("#qualityLimitationResolutionChanges").innerText = report["qualityLimitationResolutionChanges"];
+
+                            lastBytesSent = bytesSent;
+                            lastTimestamp = timestamp;
+                        }
+                    });
+                });
+            });
+        };
+
+    </script>
+</head>
+<body>
+    <video controls autoplay="autoplay" id="videoCtl" width="640" height="480"></video>
+    <div>
+        <input type="text" id="websockurl" size="40" />
+        <button type="button" class="btn btn-success" onclick="start();">Start</button>
+        <button type="button" class="btn btn-success" onclick="closePeer();">Close</button>
+    </div>
+    <div>
+        <fieldset style="width: 400px">
+            <legend>Capture Options:</legend>
+            <input type="checkbox" name="captureAudio" /> Audio <br />
+            <input type="checkbox" checked="checked" name="captureVideo" onchange="document.querySelector('#videoResOptions').disabled=!this.checked" /> Video <br />
+            <fieldset style="width: 200px" id="videoResOptions">
+                <legend>Video Resolution:</legend>
+                <input type="radio" name="videoResolution" checked="checked" value="default" /> Default<br />
+                <input type="radio" name="videoResolution" value="240p" /> 240p (320x240)<br />
+                <input type="radio" name="videoResolution" value="480p" /> 480p (640x480)<br />
+                <input type="radio" name="videoResolution" value="720p" /> 720p (1280x720)<br />
+                <input type="radio" name="videoResolution" value="1080p" /> 1080p (1920x1080)<br />
+            </fieldset>
+        </fieldset>
+    </div>
+    <div>
+        Video Bandwidth (bps): <span id="videoBandwidth"></span><br />
+        Quality Limitation Reason: <span id="qualityLimitationReason"></span><br />
+        Quality Limitation Resolution Changes: <span id="qualityLimitationResolutionChanges"></span><br />
+    </div>
+</body>
+
+<script>
+    document.querySelector('#websockurl').value = WEBSOCKET_URL;
+</script>

--- a/test/FFmpegWebRtcReceiver/captureopts_manlesdp.html
+++ b/test/FFmpegWebRtcReceiver/captureopts_manlesdp.html
@@ -1,0 +1,199 @@
+﻿<!DOCTYPE html>
+<head>
+    <meta charset="UTF-8">
+
+    <script type="text/javascript">
+
+        const STUN_URL = "stun:stun.sipsorcery.com";
+        const WEBSOCKET_URL = "ws://127.0.0.1:8081/";
+        const FRAME_RATE = 30.0;
+        const MAX_BITRATE = 10000000;
+
+        var pc, ws, statsInterval, videoSender;
+        var lastBytesSent = 0, lastTimestamp = 0;
+
+        async function start() {
+
+            // Construct the audio and video capture options from the HTML inputs.
+            let videoResFn = function (videoResStr) {
+                switch (videoResStr) {
+                    case "default": return true;
+                    case "240p": return { width: 320, height: 240, frameRate: FRAME_RATE};
+                    case "480p": return { width: 640, height: 480, frameRate: FRAME_RATE};
+                    case "720p": return { width: 1280, height: 720, frameRate: FRAME_RATE};
+                    case "1080p": return { width: 1920, height: 1080, frameRate: FRAME_RATE};
+                    default: return { };
+                }
+            };
+
+            let captureOptions = {
+                audio: false, // document.querySelector('input[name="captureAudio"]').checked,
+                video:
+                    document.querySelector('input[name="captureVideo"]').checked ?
+                        videoResFn(document.querySelector('input[name="videoResolution"]:checked').value) : false
+            };
+
+            console.log(document.querySelector('input[name="videoResolution"]:checked').value);
+            console.log(captureOptions);
+
+            // Request access to required audio/video capture devices.
+            let captureStm = await navigator.mediaDevices.getUserMedia(captureOptions);
+            document.querySelector('#videoCtl').srcObject = captureStm; // No remote streams so render local ones.
+
+            pc = new RTCPeerConnection({ iceServers: [{ urls: STUN_URL }] });
+
+            statsInterval = window.setInterval(getConnectionStats, 1000);
+
+            //pc.ontrack = evt => document.querySelector('#videoCtl').srcObject = evt.streams[0];
+            pc.onicecandidate = evt => evt.candidate && ws.send(JSON.stringify(evt.candidate));
+
+            // Diagnostics.
+            pc.onicegatheringstatechange = () => console.log("onicegatheringstatechange: " + pc.iceGatheringState);
+            pc.oniceconnectionstatechange = () => console.log("oniceconnectionstatechange: " + pc.iceConnectionState);
+            pc.onsignalingstatechange = () => console.log("onsignalingstatechange: " + pc.signalingState);
+            pc.onconnectionstatechange = () => {
+                console.log("onconnectionstatechange: " + pc.connectionState);
+                if (pc.connectionState === "connected") {
+                    pc.getSenders().forEach(async sender => {
+                        if (sender.track.kind === "video") {
+                            
+                            //var vidStmParams = sender.getParameters();
+                            //vidStmParams.encodings[0].maxBitrate = MAX_BITRATE;
+                            //await sender.setParameters(vidStmParams);
+
+                            console.log("Video stream parameters:");
+                            console.log(sender.getParameters());
+                            vidStmParams = sender.getParameters();
+                            console.log(`is active: ${vidStmParams.encodings[0].active}.`);
+                            console.log(`maxBitrate: ${vidStmParams.encodings[0].maxBitrate}.`);
+                        }
+                    });
+                }
+            }
+
+            // Add local capture streams to peer connection.
+            captureStm.getTracks().forEach(track => pc.addTrack(track, captureStm));
+            //var videotrack = captureStm.getVideoTracks()[0];
+            //videoSender = pc.addTrack(videotrack, captureStm);
+
+            //audiotrack = captureStm.getAudioTracks()[0];
+            //pc.addTrack(audiotrack, captureStm);
+
+            //var params = videoSender.getParameters();
+            //params.encodings[0].maxBitrate = 10000000;
+            //videoSender.setParameters(params);
+
+            // Web socket signaling.
+            ws = new WebSocket(document.querySelector('#websockurl').value, []);
+            ws.onmessage = async function (evt) {
+                if (/^[\{"'\s]*candidate/.test(evt.data)) {
+                    pc.addIceCandidate(JSON.parse(evt.data));
+                }
+                else {
+                    console.log(`Remote Offer: ${JSON.parse(evt.data).sdp}`);
+                    await pc.setRemoteDescription(new RTCSessionDescription(JSON.parse(evt.data)));
+                    pc.createAnswer()
+                        //.then(answer => {
+                        //    var arr = answer.sdp.split('\r\n');
+                        //    arr.forEach((str, i) => {
+                        //        if (/^c=/.test(str)) {
+                        //            arr[i] = str + '\r\n' + "b=TIAS:2147483";
+                        //        }
+                        //        else if (str === "a=rtpmap:96 VP8/90000") {
+                        //            arr[i] = str + '\r\n' + "a=fmtp:96 x-google-max-bitrate=10000000;x-google-min-bitrate=0;x-google-start-bitrate=10000000";
+                        //        }
+                        //    });
+                        //    return new RTCSessionDescription({
+                        //        type: 'answer',
+                        //        sdp: arr.join('\r\n'),
+                        //    })
+                        //})
+                        .then(answer => pc.setLocalDescription(answer))
+                        .then(() => {
+                            console.log(`Local Answer: ${pc.localDescription.sdp}`);
+                            ws.send(JSON.stringify(pc.localDescription));
+                        });
+                }
+            };
+        };
+
+        async function closePeer() {
+            document.querySelector('#videoCtl').srcObject.getTracks().forEach(function (track) {
+                track.stop();
+            });
+            pc.getSenders().forEach(sender => {
+                sender.track.stop();
+                pc.removeTrack(sender);
+            });
+            await pc.close();
+            await ws.close();
+            clearInterval(statsInterval);
+        };
+
+        function getConnectionStats() {
+
+            pc.getSenders().forEach(sender => {
+                //console.log(sender);
+
+                //let parameters = sender.getParameters();
+                //console.log(`parameters.transactionId ${parameters.transactionId}.`);
+                //parameters.encodings.forEach(enc => {
+                //    console.log(enc);
+                //    console.log(`maxBitrate=${enc.maxBitrate}.`);
+                //});
+
+                sender.getStats().then(stats => {
+                    stats.forEach(report => {
+                        if (report.type === "outbound-rtp" && report.kind === "video") {
+                            let timestamp = report["timestamp"];
+                            let bytesSent = report["bytesSent"];
+
+                            let bw = ((bytesSent - lastBytesSent) * 8) / ((timestamp - lastTimestamp) / 1000)
+
+                            document.querySelector("#videoBandwidth").innerText = bw.toFixed(0);
+
+                            document.querySelector("#qualityLimitationReason").innerText = report["qualityLimitationReason"];
+                            document.querySelector("#qualityLimitationResolutionChanges").innerText = report["qualityLimitationResolutionChanges"];
+
+                            lastBytesSent = bytesSent;
+                            lastTimestamp = timestamp;
+                        }
+                    });
+                });
+            });
+        };
+
+    </script>
+</head>
+<body>
+    <video controls autoplay="autoplay" id="videoCtl" width="640" height="480"></video>
+    <div>
+        <input type="text" id="websockurl" size="40" />
+        <button type="button" class="btn btn-success" onclick="start();">Start</button>
+        <button type="button" class="btn btn-success" onclick="closePeer();">Close</button>
+    </div>
+    <div>
+        <fieldset style="width: 400px">
+            <legend>Capture Options:</legend>
+            <input type="checkbox" checked="checked" name="captureAudio" /> Audio <br />
+            <input type="checkbox" checked="checked" name="captureVideo" onchange="document.querySelector('#videoResOptions').disabled=!this.checked" /> Video <br />
+            <fieldset style="width: 200px" id="videoResOptions">
+                <legend>Video Resolution:</legend>
+                <input type="radio" name="videoResolution" checked="checked" value="default" /> Default<br />
+                <input type="radio" name="videoResolution" value="240p" /> 240p (320x240)<br />
+                <input type="radio" name="videoResolution" value="480p" /> 480p (640x480)<br />
+                <input type="radio" name="videoResolution" value="720p" /> 720p (1280x720)<br />
+                <input type="radio" name="videoResolution" value="1080p" /> 1080p (1920x1080)<br />
+            </fieldset>
+        </fieldset>
+    </div>
+    <div>
+        Video Bandwidth (bps): <span id="videoBandwidth"></span><br />
+        Quality Limitation Reason: <span id="qualityLimitationReason"></span><br />
+        Quality Limitation Resolution Changes: <span id="qualityLimitationResolutionChanges"></span><br />
+    </div>
+</body>
+
+<script>
+    document.querySelector('#websockurl').value = WEBSOCKET_URL;
+</script>


### PR DESCRIPTION
### Content of this PR:

**Fix**
- Repeat option is now working for Audio and Video file

**Enhancements**

- FFmpegAudioDecoder: use delegate with AVFrame (to be coherent with FFmpepVideoDecoder)
- Continue simplification: centralize constants and supported audio/video formats
- FFmpegVideoSource: event OnVideoSourceRawSample has been added
- FFmpegVideoSource: decoding/encoding video has been simplified
- FFmpegFileSource: allow to subscribe/unsubscribe to OnVideoSourceRawSample and OnVideoSourceEncodedSample
- FFmpegCameraManager: allow to get the list of Camera devices (for "dshow" use third party:  "DirectShowLib.Standard" package)

