### PR TITLE
Add MonitorManager and enhance CameraManager

### DIFF
--- a/src/FFmpegCameraManager.cs
+++ b/src/FFmpegCameraManager.cs
@@ -9,9 +9,9 @@ namespace SIPSorceryMedia.FFmpeg
 {
     public unsafe class FFmpegCameraManager
     {
-        static public List<String> GetCameraDevices()
+        static public List<Camera>? GetCameraDevices()
         {
-            List<String> result = new List<string>();
+            List<Camera>? result = null;
 
             string inputFormat = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dshow"
                                     : RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "v4l2"
@@ -22,12 +22,20 @@ namespace SIPSorceryMedia.FFmpeg
             // FFmpeg doesn't implement avdevice_list_input_sources() for the DShow input format yet.
             if (inputFormat == "dshow")
             {
+                result = new List<Camera>();
                 var dsDevices = DsDevice.GetDevicesOfCat(FilterCategory.VideoInputDevice);
                 for (int i = 0; i < dsDevices.Length; i++)
                 {
                     var dsDevice = dsDevices[i];
-                    if ( (dsDevice.Name != null) && (dsDevice.Name.Length > 0) )
-                        result.Add(dsDevice.Name);
+                    if ((dsDevice.Name != null) && (dsDevice.Name.Length > 0))
+                    {
+                        Camera camera = new Camera
+                        {
+                            Name = dsDevice.Name,
+                            Path = "video=" + dsDevice.Name
+                        };
+                        result.Add(camera);
+                    }
                 }
             }
             else
@@ -39,19 +47,34 @@ namespace SIPSorceryMedia.FFmpeg
                 int nDevices = avDeviceInfoList->nb_devices;
                 var avDevices = avDeviceInfoList->devices;
 
+                result = new List<Camera>();
                 for (int i = 0; i < nDevices; i++)
                 {
                     var avDevice = avDevices[i];
                     var name = Marshal.PtrToStringAnsi((IntPtr)avDevice->device_description);
-                    //var path = Marshal.PtrToStringAnsi((IntPtr)avDevice->device_name);
+                    var path = Marshal.PtrToStringAnsi((IntPtr)avDevice->device_name);
 
                     if ((name != null) && (name.Length > 0))
-                        result.Add(name);
+                    {
+                        Camera camera = new Camera
+                        {
+                            Name = name,
+                            Path = path
+                        };
+                        result.Add(camera);
+                    }
                 }
 
                 ffmpeg.avdevice_free_list_devices(&avDeviceInfoList);
             }
             return result;
         }
+    }
+
+    public class Camera
+    {
+        public String Name { get; set; }
+
+        public String Path { get; set; }
     }
 }

--- a/src/FFmpegMonitorManager.cs
+++ b/src/FFmpegMonitorManager.cs
@@ -1,0 +1,52 @@
+﻿using FFmpeg.AutoGen;
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Drawing;
+
+using SIPSorceryMedia.FFmpeg.Interop.X11;
+using SIPSorceryMedia.FFmpeg.Interop.Win32;
+using static SIPSorceryMedia.FFmpeg.Interop.Win32.User32;
+
+namespace SIPSorceryMedia.FFmpeg
+{
+    public unsafe class FFmpegMonitorManager
+    {
+        static public List<Monitor>? GetMonitorDevices()
+        {
+            List<Monitor>? result = null ; 
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                result = User32.GetMonitors(); 
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                result = XLib.GetMonitors();
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                // TODO
+            }
+            else
+            {
+                throw new NotSupportedException($"Cannot find adequate input format - OSArchitecture:[{RuntimeInformation.OSArchitecture}] - OSDescription:[{RuntimeInformation.OSDescription}]");
+            }
+
+            return result;
+        }
+    }
+
+    public class Monitor
+    {
+        public String Name { get; set; }
+
+        public String Path { get; set; }
+
+        public Rectangle Rect { get; set; }
+
+        public Boolean Primary { get; set; }
+    }
+
+}

--- a/src/FFmpegScreenSource.cs
+++ b/src/FFmpegScreenSource.cs
@@ -16,7 +16,7 @@ namespace SIPSorceryMedia.FFmpeg
         private static ILogger logger = SIPSorcery.LogFactory.CreateLogger<FFmpegScreenSource>();
 
 
-        public unsafe FFmpegScreenSource(string path, Rectangle? rect = null)
+        public unsafe FFmpegScreenSource(string path, Rectangle rect, int frameRate = 20)
         {
             string inputFormat;
             Dictionary<String, String>? options = null;
@@ -24,32 +24,34 @@ namespace SIPSorceryMedia.FFmpeg
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 inputFormat = "gdigrab";
-                if (rect != null)
+                options = new Dictionary<string, string>()
                 {
-                    options = new Dictionary<string, string>()
-                    {
-                        ["offset_x"] = rect.Value.X.ToString(),
-                        ["offset_y"] = rect.Value.Y.ToString(),
-                        ["video_size"] = $"{rect.Value.Width.ToString()}X{rect.Value.Height.ToString()}"
-                    };
-                }
+                    ["offset_x"] = rect.X.ToString(),
+                    ["offset_y"] = rect.Y.ToString(),
+                    ["video_size"] = $"{rect.Width.ToString()}X{rect.Height.ToString()}",
+                    ["framerate"] = frameRate.ToString()
+                };
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 inputFormat = "avfoundation";
-                if (rect != null)
+                options = new Dictionary<string, string>()
                 {
-                    options = new Dictionary<string, string>()
-                    {
-                        ["vf"] = $"crop={rect.Value.Width.ToString()}:{rect.Value.Height.ToString()}:{rect.Value.X.ToString()}:{rect.Value.Y.ToString()}"
-                    };
-                }
+                    ["vf"] = $"crop={rect.Width.ToString()}:{rect.Height.ToString()}:{rect.X.ToString()}:{rect.Y.ToString()}",
+                    ["framerate"] = frameRate.ToString()
+                };
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                // TODO
                 inputFormat = "x11grab";
-                throw new NotSupportedException($"Cannot find adequate input format - OSArchitecture:[{RuntimeInformation.OSArchitecture}] - OSDescription:[{RuntimeInformation.OSDescription}]");
+                //https://superuser.com/questions/1562228/how-to-specify-the-size-to-record-the-screen-with-ffmpeg
+                options = new Dictionary<string, string>()
+                {
+                    ["video_size"] = $"{rect.Width.ToString()}X{rect.Height.ToString()}",
+                    ["grab_x"] = rect.X.ToString(),
+                    ["grab_y"] = rect.Y.ToString(),
+                    ["framerate"] = frameRate.ToString()
+                };
             }
             else
                 throw new NotSupportedException($"Cannot find adequate input format - OSArchitecture:[{RuntimeInformation.OSArchitecture}] - OSDescription:[{RuntimeInformation.OSDescription}]");

--- a/src/Interop/Win32/User32.cs
+++ b/src/Interop/Win32/User32.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace SIPSorceryMedia.FFmpeg.Interop.Win32
+{
+    internal class User32
+    {
+        const uint MONITORINFOF_PRIMARY = 1;
+
+        [StructLayout(LayoutKind.Sequential)]
+        struct Rect
+        {
+            public int left;
+            public int top;
+            public int right;
+            public int bottom;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        struct MonitorInfo
+        {
+            public uint size;
+            public Rect monitor;
+            public Rect work;
+            public uint flags;
+        }
+
+        delegate bool MonitorEnumDelegate(IntPtr hMonitor, IntPtr hdcMonitor, ref Rect lprcMonitor, IntPtr dwData);
+
+        [DllImport("user32.dll")]
+        static extern bool EnumDisplayMonitors(IntPtr hdc, IntPtr lprcClip, MonitorEnumDelegate lpfnEnum, IntPtr dwData);
+
+        [DllImport("user32.dll")]
+        static extern bool GetMonitorInfo(IntPtr hmon, ref MonitorInfo mi);
+
+
+    #region PUBLIC
+
+        public static List<Monitor> GetMonitors()
+        {
+            List<Monitor> result = new List<Monitor> ();
+            int index = 0;
+            EnumDisplayMonitors(IntPtr.Zero, IntPtr.Zero,
+                    delegate (IntPtr hMonitor, IntPtr hdcMonitor, ref Rect lprcMonitor, IntPtr dwData)
+                    {
+                        MonitorInfo mi = new MonitorInfo();
+                        mi.size = (uint)Marshal.SizeOf(mi);
+                        bool success = GetMonitorInfo(hMonitor, ref mi);
+
+                        Monitor monitor = new Monitor
+                        {
+                            Name = $"{index++}",
+                            Path = "desktop",
+                            Rect = new Rectangle(mi.monitor.left, mi.monitor.top, mi.monitor.right - mi.monitor.left, mi.monitor.bottom - mi.monitor.top),
+                            Primary = mi.flags == MONITORINFOF_PRIMARY,
+                        };
+                        result.Add(monitor);
+                        return true;
+                    }, 
+                    IntPtr.Zero);
+            return result;
+        }
+
+    #endregion PUBLIC
+
+    }
+}

--- a/src/Interop/X11/XLib.cs
+++ b/src/Interop/X11/XLib.cs
@@ -1,0 +1,66 @@
+
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Runtime.InteropServices;
+
+namespace SIPSorceryMedia.FFmpeg.Interop.X11
+{
+    using Display = IntPtr;
+    using Window = IntPtr;
+
+    internal class XLib
+    {
+        private const string lib_x11 = "libX11";
+        private static readonly object displayLock = new object();
+
+        [DllImport(lib_x11, EntryPoint = "XOpenDisplay")]
+        private static extern unsafe Display sys_XOpenDisplay(sbyte* display);
+        public static unsafe Display XOpenDisplay(sbyte* display)
+        {
+            lock (displayLock)
+                return sys_XOpenDisplay(display);
+        }
+
+        [DllImport(lib_x11, EntryPoint = "XCloseDisplay")]
+        public static extern int XCloseDisplay(Display display);
+
+        [DllImport(lib_x11, EntryPoint = "XDefaultRootWindow")]
+        public static extern Window XDefaultRootWindow(Display display);
+
+        [DllImport(lib_x11, EntryPoint = "XDisplayWidth")]
+        public static extern int XDisplayWidth(Display display, int screenNumber);
+
+        [DllImport(lib_x11, EntryPoint = "XDisplayHeight")]
+        public static extern int XDisplayHeight(Display display, int screenNumber);
+
+
+        public static List<Monitor> GetMonitors()
+        {
+            List<Monitor> result = new List<Monitor>();
+            unsafe
+            {
+                IntPtr display = XLib.XOpenDisplay(null);
+                IntPtr rootWindow = XLib.XDefaultRootWindow(display);
+                XRRMonitorInfo* monitors = XRandr.XRRGetMonitors(display, rootWindow, true, out int count);
+                for (int i = 0; i < count; i++)
+                {
+                    XRRMonitorInfo monitor = monitors[i];
+                    string nameAddition = monitor.Name == null ? "" : $" ({new string(monitor.Name)})";
+
+                    Monitor m = new Monitor
+                    {
+                        Name = $"{i}{nameAddition}",
+                        Path = ":0",
+                        Rect = new Rectangle(monitor.X, monitor.Y, monitor.Width, monitor.Height),
+                        Primary = monitor.Primary > 0,
+                    };
+                    result.Add(m);
+                }
+            }
+            return result;
+        }
+
+    }
+}

--- a/src/Interop/X11/XRRMonitorInfo.cs
+++ b/src/Interop/X11/XRRMonitorInfo.cs
@@ -1,0 +1,25 @@
+// Copyright (c) The Vignette Authors
+// This file is part of SeeShark.
+// SeeShark is licensed under the BSD 3-Clause License. See LICENSE for details.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace SIPSorceryMedia.FFmpeg.Interop.X11
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct XRRMonitorInfo
+    {
+        public sbyte* Name;
+        public int Primary;
+        public int Automatic;
+        public int NOutput;
+        public int X;
+        public int Y;
+        public int Width;
+        public int Height;
+        public int MWidth;
+        public int MHeight;
+        public IntPtr Outputs;
+    }
+}

--- a/src/Interop/X11/XRandr.cs
+++ b/src/Interop/X11/XRandr.cs
@@ -1,0 +1,20 @@
+// Copyright (c) The Vignette Authors
+// This file is part of SeeShark.
+// SeeShark is licensed under the BSD 3-Clause License. See LICENSE for details.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace SIPSorceryMedia.FFmpeg.Interop.X11
+{
+    using Display = IntPtr;
+    using Window = IntPtr;
+
+    internal static class XRandr
+    {
+        private const string lib_x_randr = "libXrandr";
+
+        [DllImport(lib_x_randr, EntryPoint = "XRRGetMonitors")]
+        public static extern unsafe XRRMonitorInfo* XRRGetMonitors(Display dpy, Window window, bool getActive, out int nmonitors);
+    }
+}


### PR DESCRIPTION
Add **FFmpegMonitorManager** to get monitors list. For this, use interop (X11Lib for Linux and Win32 for Windows)
Enhance **FFmpegCameraManager** (need a Name and a Path)

Update **FFmpegFileAndDevicesTest**:

- use **FFmpegCameraManager** and use **FFmpegMonitorManager** to show how to use them