### PR TITLE
Enhance Audio Source encoding

### DIFF
--- a/src/BasicBufferShort.cs
+++ b/src/BasicBufferShort.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SIPSorceryMedia.FFmpeg
+{
+    /// <summary>
+    /// A drop-in implementation of BasicBuffer strongly typed to the int16 data.
+    /// This has better performance in the CLR because it avoids the boxed arrays used in the generic buffer class
+    /// </summary>
+    public class BasicBufferShort
+    {
+        private short[] data;
+        private int writeIndex = 0;
+        private int readIndex = 0;
+        private int available = 0;
+        private int capacity = 0;
+
+        public BasicBufferShort(int capacity)
+        {
+            this.capacity = capacity;
+            data = new short[capacity];
+        }
+
+        public void Write(short[] toWrite)
+        {
+            // Write the data in chunks
+            int sourceIndex = 0;
+            while (sourceIndex < toWrite.Length)
+            {
+                int count = Math.Min(toWrite.Length - sourceIndex, capacity - writeIndex);
+                Array.Copy(toWrite, sourceIndex, data, writeIndex, count);
+                writeIndex = (writeIndex + count) % capacity;
+                sourceIndex += count;
+            }
+            available += toWrite.Length;
+            // Did we overflow? In this case, move the readIndex to just after the writeIndex
+            if (available > capacity)
+            {
+                readIndex = (writeIndex + 1) % capacity;
+                available = capacity;
+            }
+        }
+
+        /// <summary>
+        /// Writes a single value
+        /// </summary>
+        /// <param name="toWrite"></param>
+        public void Write(short toWrite)
+        {
+            data[writeIndex] = toWrite;
+            writeIndex = (writeIndex + 1) % capacity;
+            available += 1;
+            if (available > capacity)
+            {
+                readIndex = (writeIndex + 1) % capacity;
+                available = capacity;
+            }
+        }
+
+        public void Clear()
+        {
+            writeIndex = 0;
+            readIndex = 0;
+            available = 0;
+        }
+
+        public short[] Read(int count)
+        {
+            short[] returnVal = new short[count];
+            // Read the data in chunks
+            int sourceIndex = 0;
+            while (sourceIndex < count)
+            {
+                int readCount = Math.Min(count - sourceIndex, capacity - readIndex);
+                Array.Copy(data, readIndex, returnVal, sourceIndex, readCount);
+                readIndex = (readIndex + readCount) % capacity;
+                sourceIndex += readCount;
+            }
+            available -= count;
+            // Did we underflow? In this case, move the writeIndex to where the next data will be read
+            if (available < 0)
+            {
+                writeIndex = (readIndex + 1) % capacity;
+                available = 0;
+            }
+            return returnVal;
+        }
+
+        /// <summary>
+        /// Reads a single value
+        /// </summary>
+        /// <returns></returns>
+        public short Read()
+        {
+            short returnVal = data[readIndex];
+            readIndex = (readIndex + 1) % capacity;
+            available -= 1;
+            if (available < 0)
+            {
+                writeIndex = (readIndex + 1) % capacity;
+                available = 0;
+            }
+            return returnVal;
+        }
+
+        /// <summary>
+        /// Reads from the buffer without actually consuming the data
+        /// </summary>
+        /// <param name="count"></param>
+        /// <returns></returns>
+        public short[] Peek(int count)
+        {
+            int toRead = Math.Min(available, count);
+            short[] returnVal = new short[toRead];
+            // Read the data in chunks
+            int sourceIndex = 0;
+            int localReadIndex = readIndex;
+            while (sourceIndex < toRead)
+            {
+                int readCount = Math.Min(toRead - sourceIndex, capacity - localReadIndex);
+                Array.Copy(data, localReadIndex, returnVal, sourceIndex, readCount);
+                localReadIndex = (localReadIndex + readCount) % capacity;
+                sourceIndex += readCount;
+            }
+            return returnVal;
+        }
+
+        public int Available()
+        {
+            return available;
+        }
+
+        public int Capacity()
+        {
+            return capacity;
+        }
+    }
+}

--- a/src/FFmpegFileSource.cs
+++ b/src/FFmpegFileSource.cs
@@ -33,7 +33,7 @@ namespace SIPSorceryMedia.FFmpeg
         public event SourceErrorDelegate? OnVideoSourceError;
 #pragma warning restore CS0067
 
-        public unsafe FFmpegFileSource(string path, bool repeat, IAudioEncoder audioEncoder, bool useVideo = true)
+        public unsafe FFmpegFileSource(string path, bool repeat, IAudioEncoder audioEncoder, uint audioFrameSize = 960, bool useVideo = true)
         {
             if (!File.Exists(path))
             {
@@ -43,9 +43,8 @@ namespace SIPSorceryMedia.FFmpeg
 
             if ((audioEncoder != null))
             {
-                _FFmpegAudioSource = new FFmpegAudioSource(audioEncoder);
+                _FFmpegAudioSource = new FFmpegAudioSource(audioEncoder, audioFrameSize);
                 _FFmpegAudioSource.CreateAudioDecoder(path, null, repeat, false);
-                _FFmpegAudioSource.InitialiseDecoder();
 
                 _FFmpegAudioSource.OnAudioSourceEncodedSample += _FFmpegAudioSource_OnAudioSourceEncodedSample;
                 _FFmpegAudioSource.OnAudioSourceRawSample += _FFmpegAudioSource_OnAudioSourceRawSample;

--- a/src/FFmpegMicrophoneSource.cs
+++ b/src/FFmpegMicrophoneSource.cs
@@ -14,7 +14,7 @@ namespace SIPSorceryMedia.FFmpeg
     {
         private static ILogger logger = SIPSorcery.LogFactory.CreateLogger<FFmpegMicrophoneSource>();
 
-        public unsafe FFmpegMicrophoneSource(string path, IAudioEncoder audioEncoder): base(audioEncoder)
+        public unsafe FFmpegMicrophoneSource(string path, IAudioEncoder audioEncoder, uint frameSize = 960) : base(audioEncoder, frameSize)
         {
             string inputFormat = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dshow"
                 : RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "alsa"
@@ -24,8 +24,6 @@ namespace SIPSorceryMedia.FFmpeg
             AVInputFormat* aVInputFormat = ffmpeg.av_find_input_format(inputFormat);
 
             CreateAudioDecoder(path, aVInputFormat, false, true);
-
-            InitialiseDecoder();
         }
     }
 }

--- a/src/FFmpegVideoEndPoint.cs
+++ b/src/FFmpegVideoEndPoint.cs
@@ -62,19 +62,21 @@ namespace SIPSorceryMedia.FFmpeg
         {
             if ( (!_isClosed) && (payload != null) )
             {
-                AVCodecID codecID = FFmpegConvert.GetAVCodecID(_videoFormatManager.SelectedFormat.Codec);
+                AVCodecID? codecID = FFmpegConvert.GetAVCodecID(_videoFormatManager.SelectedFormat.Codec);
+                if(codecID != null)
+                { 
+                    var imageRawSamples = _ffmpegEncoder.DecodeFaster(codecID.Value, payload, out var width, out var height);
 
-                var imageRawSamples = _ffmpegEncoder.DecodeFaster(codecID, payload, out var width, out var height);
-
-                if (imageRawSamples == null || width == 0 || height == 0)
-                {
-                    logger.LogWarning($"Decode of video sample failed, width {width}, height {height}.");
-                }
-                else
-                {
-                    foreach (var imageRawSample in imageRawSamples)
+                    if (imageRawSamples == null || width == 0 || height == 0)
                     {
-                        OnVideoSinkDecodedSampleFaster?.Invoke(imageRawSample);
+                        logger.LogWarning($"Decode of video sample failed, width {width}, height {height}.");
+                    }
+                    else
+                    {
+                        foreach (var imageRawSample in imageRawSamples)
+                        {
+                            OnVideoSinkDecodedSampleFaster?.Invoke(imageRawSample);
+                        }
                     }
                 }
             }

--- a/src/FFmpegVideoSource.cs
+++ b/src/FFmpegVideoSource.cs
@@ -149,16 +149,18 @@ namespace SIPSorceryMedia.FFmpeg
                     var frameYUV420P = _videoFrameYUV420PConverter.Convert(frame);
                     if ((frameYUV420P.width != 0) && (frameYUV420P.height != 0))
                     {
-                        AVCodecID aVCodecId = FFmpegConvert.GetAVCodecID(_videoFormatManager.SelectedFormat.Codec);
+                        AVCodecID? aVCodecId = FFmpegConvert.GetAVCodecID(_videoFormatManager.SelectedFormat.Codec);
+                        if(aVCodecId != null)
+                        { 
+                            byte[]? encodedSample = _videoEncoder.Encode(aVCodecId.Value, frameYUV420P, frameRate);
 
-                        byte[]? encodedSample = _videoEncoder.Encode(aVCodecId, frameYUV420P, frameRate);
-
-                        if (encodedSample != null)
-                        {
-                            // Note the event handler can be removed while the encoding is in progress.
-                            OnVideoSourceEncodedSample?.Invoke(timestampDuration, encodedSample);
+                            if (encodedSample != null)
+                            {
+                                // Note the event handler can be removed while the encoding is in progress.
+                                OnVideoSourceEncodedSample?.Invoke(timestampDuration, encodedSample);
+                            }
+                            _forceKeyFrame = false;
                         }
-                        _forceKeyFrame = false;
                     }
                     else
                         _forceKeyFrame = true;

--- a/src/FfmpegInit.cs
+++ b/src/FfmpegInit.cs
@@ -59,7 +59,7 @@ namespace SIPSorceryMedia.FFmpeg
                 var printPrefix = 1;
                 ffmpeg.av_log_format_line(p0, level, format, vl, lineBuffer, lineSize, &printPrefix);
                 var line = Marshal.PtrToStringAnsi((IntPtr)lineBuffer);
-                Console.Write(line);
+                //Console.Write(line);
                 if (storeLogs)
                     storedLogs += line;
             };
@@ -150,9 +150,9 @@ namespace SIPSorceryMedia.FFmpeg
 
     public static class FFmpegConvert
     {
-        public static AVCodecID GetAVCodecID(VideoCodecsEnum videoCodec)
+        public static AVCodecID? GetAVCodecID(VideoCodecsEnum videoCodec)
         {
-            var avCodecID = AVCodecID.AV_CODEC_ID_VP8;
+            AVCodecID? avCodecID = null;
             switch (videoCodec)
             {
                 case VideoCodecsEnum.VP8:
@@ -161,8 +161,6 @@ namespace SIPSorceryMedia.FFmpeg
                 case VideoCodecsEnum.H264:
                     avCodecID = AVCodecID.AV_CODEC_ID_H264;
                     break;
-                default:
-                    throw new ApplicationException($"FFmpeg video source, selected video codec {videoCodec} is not supported.");
             }
 
             return avCodecID;

--- a/src/Helper.cs
+++ b/src/Helper.cs
@@ -9,10 +9,6 @@ namespace SIPSorceryMedia.FFmpeg
     public class Helper
     {
         public const int MIN_SLEEP_MILLISECONDS = 15;
-
-        public const int VIDEO_SAMPLING_RATE = 90000;
-        public const int AUDIO_SAMPLING_RATE = 8000;
-
         public const int DEFAULT_VIDEO_FRAME_RATE = 30;
 
         public const int VP8_FORMATID = 96;
@@ -20,16 +16,8 @@ namespace SIPSorceryMedia.FFmpeg
 
         internal static List<VideoFormat> GetSupportedVideoFormats() => new List<VideoFormat>
         {
-            new VideoFormat(VideoCodecsEnum.VP8, Helper.VP8_FORMATID, Helper.VIDEO_SAMPLING_RATE),
-            new VideoFormat(VideoCodecsEnum.H264, Helper.H264_FORMATID, Helper.VIDEO_SAMPLING_RATE)
+            new VideoFormat(VideoCodecsEnum.VP8, Helper.VP8_FORMATID, VideoFormat.DEFAULT_CLOCK_RATE),
+            new VideoFormat(VideoCodecsEnum.H264, Helper.H264_FORMATID, VideoFormat.DEFAULT_CLOCK_RATE)
         };
-
-        internal static List<AudioFormat> GetSupportedAudioFormats() => new List<AudioFormat>
-        {
-            new AudioFormat(SDPWellKnownMediaFormatsEnum.PCMU),
-            new AudioFormat(SDPWellKnownMediaFormatsEnum.PCMA),
-            new AudioFormat(SDPWellKnownMediaFormatsEnum.G722)
-        };
-
     }
 }


### PR DESCRIPTION
Enhance Audio Source encoding:
- frame size can be set for encoding process
- clock rate and rtp clock rate from Codec is correctly used

Tested with this Audio Codecs: PCMU (G711), PCMA (G711), G722, G729 and Opus

More details:
FFmpegAudioDecoder: clockrate must be set to init it
FFmpegAudioSource, FFmpegMicrophoneSource, FFmpegFileSource: frame size can be set for Audio encoding purpose
FFmpegAudioSource: use frame size for encoding and set correct duration when using OnAudioSourceEncodedSample
Helper: remove unnecessary code