### PR TITLE
Small improvement and remove compilation warnings 

### DIFF
--- a/src/FFmpegCameraManager.cs
+++ b/src/FFmpegCameraManager.cs
@@ -32,7 +32,7 @@ namespace SIPSorceryMedia.FFmpeg
                         Camera camera = new Camera
                         {
                             Name = dsDevice.Name,
-                            Path = "video=" + dsDevice.Name
+                            Path = $"video={dsDevice.Name}"
                         };
                         result.Add(camera);
                     }
@@ -62,8 +62,8 @@ namespace SIPSorceryMedia.FFmpeg
                     {
                         Camera camera = new Camera
                         {
-                            Name = name,
-                            Path = path
+                            Name = (name == null) ? "" : name,
+                            Path = (path == null) ? "" : path,
                         };
                         result.Add(camera);
                     }
@@ -80,5 +80,10 @@ namespace SIPSorceryMedia.FFmpeg
         public String Name { get; set; }
 
         public String Path { get; set; }
+
+        public Camera()
+        {
+            Name = Path = "";
+        }
     }
 }

--- a/src/FFmpegFileSource.cs
+++ b/src/FFmpegFileSource.cs
@@ -33,11 +33,11 @@ namespace SIPSorceryMedia.FFmpeg
         public event SourceErrorDelegate? OnVideoSourceError;
 #pragma warning restore CS0067
 
-        public unsafe FFmpegFileSource(string path, bool repeat, IAudioEncoder audioEncoder, uint audioFrameSize = 960, bool useVideo = true)
+        public unsafe FFmpegFileSource(string path, bool repeat, IAudioEncoder? audioEncoder, uint audioFrameSize = 960, bool useVideo = true)
         {
             if (!File.Exists(path))
             {
-                if (!Uri.TryCreate(path, UriKind.Absolute, out Uri result))
+                if (!Uri.TryCreate(path, UriKind.Absolute, out Uri? result))
                     throw new ApplicationException($"Requested path is not a valid file path or not a valid Uri: {path}.");
             }
 

--- a/src/FFmpegMonitorManager.cs
+++ b/src/FFmpegMonitorManager.cs
@@ -46,6 +46,11 @@ namespace SIPSorceryMedia.FFmpeg
         public Rectangle Rect { get; set; }
 
         public Boolean Primary { get; set; }
+
+        public Monitor()
+        {
+            Name = Path = "";
+        }
     }
 
 }

--- a/src/FFmpegVideoEndPoint.cs
+++ b/src/FFmpegVideoEndPoint.cs
@@ -22,7 +22,10 @@ namespace SIPSorceryMedia.FFmpeg
         private bool _isClosed;
         private bool _forceKeyFrame;
 
+#pragma warning disable CS0067
         public event VideoSinkSampleDecodedDelegate? OnVideoSinkDecodedSample;
+#pragma warning restore CS0067
+
         public event VideoSinkSampleDecodedFasterDelegate? OnVideoSinkDecodedSampleFaster;
 
 #pragma warning disable CS0067
@@ -60,7 +63,7 @@ namespace SIPSorceryMedia.FFmpeg
 
         public void GotVideoFrame(IPEndPoint remoteEndPoint, uint timestamp, byte[] payload, VideoFormat format)
         {
-            if ( (!_isClosed) && (payload != null) )
+            if ( (!_isClosed) && (payload != null) && (OnVideoSinkDecodedSampleFaster != null) )
             {
                 AVCodecID? codecID = FFmpegConvert.GetAVCodecID(_videoFormatManager.SelectedFormat.Codec);
                 if(codecID != null)

--- a/src/FfmpegInit.cs
+++ b/src/FfmpegInit.cs
@@ -25,7 +25,7 @@ namespace SIPSorceryMedia.FFmpeg
         private static ILogger logger = NullLogger.Instance;
         private static bool registered = false;
 
-        private static av_log_set_callback_callback logCallback;
+        private static av_log_set_callback_callback? logCallback;
         private static String storedLogs = "";
 
         public static String GetStoredLogs(Boolean clear = true)
@@ -73,7 +73,7 @@ namespace SIPSorceryMedia.FFmpeg
             ffmpeg.av_log_set_callback(logCallback);
         }
 
-        public static void Initialise(FfmpegLogLevelEnum? logLevel = null, String? libPath = null, ILogger appLogger = null)
+        public static void Initialise(FfmpegLogLevelEnum? logLevel = null, String? libPath = null, ILogger? appLogger = null)
         {
             RegisterFFmpegBinaries(libPath);
 

--- a/src/Interop/MacOs/AvFoundation.cs
+++ b/src/Interop/MacOs/AvFoundation.cs
@@ -56,7 +56,7 @@ namespace SIPSorceryMedia.FFmpeg.Interop.MacOS
                 if (logs.Contains(AVFOUNDATION_VIDEO_DEVICE_LOG_OUTPUT))
                 {
                     String[] lines = logs.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
-                    String header = null;
+                    String? header = null;
                     int index;
 
                     foreach (String line in lines)
@@ -120,7 +120,7 @@ namespace SIPSorceryMedia.FFmpeg.Interop.MacOS
                 if (logs.Contains(AVFOUNDATION_VIDEO_DEVICE_LOG_OUTPUT))
                 {
                     String[] lines = logs.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
-                    String header = null;
+                    String? header = null;
                     int index;
 
                     foreach (String line in lines)

--- a/src/SIPSorceryMedia.FFmpeg.csproj
+++ b/src/SIPSorceryMedia.FFmpeg.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
@@ -24,10 +24,10 @@
   
   <ItemGroup>
     <PackageReference Include="DirectShowLib.Standard" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="SIPSorceryMedia.Abstractions" Version="1.2.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="FFmpeg.AutoGen" Version="4.4.1.1" />
   </ItemGroup>
+  
 
 </Project>

--- a/src/VideoFrameConverter.cs
+++ b/src/VideoFrameConverter.cs
@@ -55,8 +55,6 @@ namespace SIPSorceryMedia.FFmpeg
             ffmpeg.av_image_fill_arrays(ref _dstData, ref _dstLinesize, (byte*)_convertedFrameBufferPtr, destinationPixelFormat, dstWidth, dstHeight, 1)
                 .ThrowExceptionIfError();
 
-            logger.LogDebug($"Successfully initialised ffmpeg based image converted for {srcWidth}:{srcHeight}:{sourcePixelFormat}->{dstWidth}:{dstHeight}:{_dstPixelFormat}.");
-
 
             _dstFrame = ffmpeg.av_frame_alloc();
             _dstFrame->width = _dstWidth;
@@ -64,6 +62,8 @@ namespace SIPSorceryMedia.FFmpeg
             _dstFrame->data.UpdateFrom(_dstData);
             _dstFrame->linesize.UpdateFrom(_dstLinesize);
             _dstFrame->format = (int)_dstPixelFormat;
+
+            logger.LogDebug($"Successfully initialised ffmpeg based image converted for {srcWidth}:{srcHeight}:{sourcePixelFormat}->{dstWidth}:{dstHeight}:{_dstPixelFormat}.");
         }
 
         public void Dispose()


### PR DESCRIPTION
### PR Content:

- For some files going back to theirs beginning failed using avformat_seek_file. In this (rare) case, we restart all the decoding process for the beginning. 

- Update code to remove compilation warnings

- Remove unnecessary reference to package Microsoft.Extensions.Logging.Abstractions. 

- Increase release to 1.1.1sd
