### PR TITLE
Some fixes/enhancements: CCTV support, use event instead of Exceptions, pause/resume

### DIFF
--- a/src/FFmpegVideoDecoder.cs
+++ b/src/FFmpegVideoDecoder.cs
@@ -39,6 +39,11 @@ namespace SIPSorceryMedia.FFmpeg
             get => _videoAvgFrameRate;
         }
 
+        public double VideoFrameSpace
+        {
+            get => _maxVideoFrameSpace;
+        }
+
         public unsafe FFmpegVideoDecoder(string url, AVInputFormat* inputFormat, bool repeat = false, bool isCamera = false)
         {
             _sourceUrl = url;
@@ -93,7 +98,13 @@ namespace SIPSorceryMedia.FFmpeg
                 ffmpeg.avcodec_open2(_vidDecCtx, vidCodec, null).ThrowExceptionIfError();
 
                 _videoTimebase = ffmpeg.av_q2d(_fmtCtx->streams[_videoStreamIndex]->time_base);
+                if (Double.IsNaN(_videoTimebase) || (_videoTimebase <= 0) )
+                    _videoTimebase = 0.001;
+
                 _videoAvgFrameRate = ffmpeg.av_q2d(_fmtCtx->streams[_videoStreamIndex]->avg_frame_rate);
+                if (Double.IsNaN(_videoAvgFrameRate) || (_videoAvgFrameRate <= 0))
+                    _videoAvgFrameRate = 2;
+
                 _maxVideoFrameSpace = (int)(_videoAvgFrameRate > 0 ? 1000 / _videoAvgFrameRate : 1000 / Helper.DEFAULT_VIDEO_FRAME_RATE);
             }
         }

--- a/src/FFmpegVideoEncoder.cs
+++ b/src/FFmpegVideoEncoder.cs
@@ -145,12 +145,19 @@ namespace SIPSorceryMedia.FFmpeg
                 _encoderContext->height = height;
                 _encoderContext->time_base.den = fps;
                 _encoderContext->time_base.num = 1;
+                _encoderContext->framerate.den = 1;
+                _encoderContext->framerate.num = fps;
+
                 _encoderContext->pix_fmt = AVPixelFormat.AV_PIX_FMT_YUV420P;
-                
+
+                // Set Key frame interval
+                if (fps < 5)
+                    _encoderContext->gop_size = 1;
+                else
+                    _encoderContext->gop_size = fps;
+
                 if (_codecID == AVCodecID.AV_CODEC_ID_H264)
                 {
-                    _encoderContext->gop_size = 30; // Key frame interval.
-
                     //_videoCodecContext->profile = ffmpeg.FF_PROFILE_H264_CONSTRAINED_BASELINE;
                     ffmpeg.av_opt_set(_encoderContext->priv_data, "profile", "baseline", 0).ThrowExceptionIfError();
                     //ffmpeg.av_opt_set(_videoCodecContext->priv_data, "packetization-mode", "0", 0).ThrowExceptionIfError();

--- a/src/FFmpegVideoSource.cs
+++ b/src/FFmpegVideoSource.cs
@@ -95,8 +95,7 @@ namespace SIPSorceryMedia.FFmpeg
             if ( (_videoDecoder != null) && ((OnVideoSourceEncodedSample != null) || (OnVideoSourceRawSampleFaster != null)) )
             {
                 int frameRate = (int)_videoDecoder.VideoAverageFrameRate;
-                frameRate = (frameRate <= 0) ? Helper.DEFAULT_VIDEO_FRAME_RATE : frameRate;
-                uint timestampDuration = (uint)(VideoFormat.DEFAULT_CLOCK_RATE / frameRate);
+                uint timestampDuration = (uint)_videoDecoder.VideoFrameSpace;
 
                 var width = frame.width;
                 var height = frame.height;

--- a/src/SIPSorceryMedia.FFmpeg.csproj
+++ b/src/SIPSorceryMedia.FFmpeg.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.1.1</Version>
+    <Version>1.2</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>

--- a/test/FFmpegEncodingTest/Program.cs
+++ b/test/FFmpegEncodingTest/Program.cs
@@ -176,7 +176,7 @@ namespace FFmpegEncodingTest
         {
             var videoCapabilities = new List<SDPAudioVideoMediaFormat>
                 {
-                    new SDPAudioVideoMediaFormat(new VideoFormat(VideoCodecsEnum.H264, Helper.H264_FORMATID, Helper.VIDEO_SAMPLING_RATE))
+                    new SDPAudioVideoMediaFormat(new VideoFormat(VideoCodecsEnum.H264, Helper.H264_FORMATID, Helper.DEFAULT_VIDEO_FRAME_RATE))
                     
                 };
             int payloadID = Convert.ToInt32(videoCapabilities.First().ID);

--- a/test/FFmpegFileAndDevicesTest/Program.cs
+++ b/test/FFmpegFileAndDevicesTest/Program.cs
@@ -63,6 +63,7 @@ namespace FFmpegFileAndDevicesTest
         //  /!\   Define some path/urls to some media files - to be set according your environment
         static private string LOCAL_AUDIO_AND_VIDEO_FILE_MP4_BUNNY = @"C:\media\big_buck_bunny.mp4";
         static private string LOCAL_AUDIO_AND_VIDEO_FILE_MP4_MAX = @"C:\media\max_intro.mp4";
+        static private string LOCAL_AUDIO_AND_VIDEO_FILE_WEBM = @"C:\media\Joy_and_Heron.webm";
 
         static private string LOCAL_AUDIO_FILE_MP3 = @"C:\media\simplest_ffmpeg_audio_decoder_skycity1.mp3";
         static private string LOCAL_AUDIO_FILE_WAV = @"C:\media\file_example_WAV_5MG.wav";
@@ -138,7 +139,7 @@ namespace FFmpegFileAndDevicesTest
                     // Do we use same file for Audio ?
                     if ((AudioSourceType == AUDIO_SOURCE.FILE_OR_STREAM)  && (AudioSourceFile == VideoSourceFile))
                     {
-                        SIPSorceryMedia.FFmpeg.FFmpegFileSource fileSource = new SIPSorceryMedia.FFmpeg.FFmpegFileSource(VideoSourceFile, RepeatVideoFile, new AudioEncoder(), true);
+                        SIPSorceryMedia.FFmpeg.FFmpegFileSource fileSource = new SIPSorceryMedia.FFmpeg.FFmpegFileSource(VideoSourceFile, RepeatVideoFile, new AudioEncoder(), 960, true);
                         fileSource.OnEndOfFile += () => PeerConnection.Close("source eof");
 
                         videoSource = fileSource as IVideoSource;
@@ -146,7 +147,7 @@ namespace FFmpegFileAndDevicesTest
                     }
                     else
                     {
-                        SIPSorceryMedia.FFmpeg.FFmpegFileSource fileSource = new SIPSorceryMedia.FFmpeg.FFmpegFileSource(VideoSourceFile, RepeatVideoFile, new AudioEncoder(), true);
+                        SIPSorceryMedia.FFmpeg.FFmpegFileSource fileSource = new SIPSorceryMedia.FFmpeg.FFmpegFileSource(VideoSourceFile, RepeatVideoFile, new AudioEncoder(), 960, true);
                         fileSource.OnEndOfFile += () => PeerConnection.Close("source eof");
 
                         videoSource = fileSource as IVideoSource;
@@ -198,7 +199,7 @@ namespace FFmpegFileAndDevicesTest
                 switch(AudioSourceType)
                 {
                     case AUDIO_SOURCE.FILE_OR_STREAM:
-                        SIPSorceryMedia.FFmpeg.FFmpegFileSource fileSource = new SIPSorceryMedia.FFmpeg.FFmpegFileSource(AudioSourceFile, RepeatAudioFile, new AudioEncoder(), false);
+                        SIPSorceryMedia.FFmpeg.FFmpegFileSource fileSource = new SIPSorceryMedia.FFmpeg.FFmpegFileSource(AudioSourceFile, RepeatAudioFile, new AudioEncoder(), 960, false);
                         fileSource.OnEndOfFile += () => PeerConnection.Close("source eof");
 
                         audioSource = fileSource as IAudioSource;


### PR DESCRIPTION

**Fixes:**
- Pause / Resume: Really pause / resume stream (Audio or Video) - before packets where just dropped
- Support low video frame rate (like CCTV)

**Enhancements:**

Avoid to throw exception when FFmpeg actions cannot be done:
- FFmpegAudioDecoder / FFmpegVideoDecoder: use event OnError
- FFmpegAudioSource: use event OnAudioSourceError
- FFmpegVideoSource: use event OnVideoSourceError
- FFmpegFileSource: use event OnAudioSourceError and OnVideoSourceError