### PR TITLE
For coherency remove event OnEndOfFile and use instead OnAudioSourceError or OnVideoSourceError.

### DIFF
--- a/src/FFmpegAudioDecoder.cs
+++ b/src/FFmpegAudioDecoder.cs
@@ -315,13 +315,7 @@ namespace SIPSorceryMedia.FFmpeg
                     }
                     else
                     {
-                        if (_isMicrophone)
-                        {
-                            RaiseError("Cannot read more frame");
-                            return;
-                        }
-                        else
-                            OnEndOfFile?.Invoke();
+                        OnEndOfFile?.Invoke();
                     }
                 }
             }

--- a/src/FFmpegFileSource.cs
+++ b/src/FFmpegFileSource.cs
@@ -24,8 +24,6 @@ namespace SIPSorceryMedia.FFmpeg
         public event EncodedSampleDelegate? OnVideoSourceEncodedSample;
         public event RawVideoSampleFasterDelegate? OnVideoSourceRawSampleFaster;
 
-        public event Action? OnEndOfFile;
-
         public event SourceErrorDelegate? OnAudioSourceError;
         public event SourceErrorDelegate? OnVideoSourceError;
 
@@ -50,7 +48,6 @@ namespace SIPSorceryMedia.FFmpeg
 
                 _FFmpegAudioSource.OnAudioSourceEncodedSample += _FFmpegAudioSource_OnAudioSourceEncodedSample;
                 _FFmpegAudioSource.OnAudioSourceRawSample += _FFmpegAudioSource_OnAudioSourceRawSample;
-                _FFmpegAudioSource.OnEndOfFile += _FFmpegAudioSource_OnEndOfFile;
                 _FFmpegAudioSource.OnAudioSourceError += _FFmpegAudioSource_OnAudioSourceError;
             }
 
@@ -58,11 +55,9 @@ namespace SIPSorceryMedia.FFmpeg
             {
                 _FFmpegVideoSource = new FFmpegVideoSource();
                 _FFmpegVideoSource.CreateVideoDecoder(path, null, repeat, false);
-                _FFmpegVideoSource.InitialiseDecoder();
 
                 _FFmpegVideoSource.OnVideoSourceEncodedSample += _FFmpegVideoSource_OnVideoSourceEncodedSample;
                 _FFmpegVideoSource.OnVideoSourceRawSampleFaster += _FFmpegVideoSource_OnVideoSourceRawSampleFaster;
-                _FFmpegVideoSource.OnEndOfFile += _FFmpegVideoSource_OnEndOfFile;
                 _FFmpegVideoSource.OnVideoSourceError += _FFmpegVideoSource_OnVideoSourceError;
             }
         }
@@ -75,16 +70,6 @@ namespace SIPSorceryMedia.FFmpeg
         private void _FFmpegVideoSource_OnVideoSourceError(string errorMessage)
         {
             OnVideoSourceError?.Invoke(errorMessage);
-        }
-
-        private void _FFmpegVideoSource_OnEndOfFile()
-        {
-            OnEndOfFile?.Invoke();
-        }
-
-        private void _FFmpegAudioSource_OnEndOfFile()
-        {
-            OnEndOfFile?.Invoke();
         }
 
         private void _FFmpegVideoSource_OnVideoSourceEncodedSample(uint durationRtpUnits, byte[] sample)
@@ -288,7 +273,6 @@ namespace SIPSorceryMedia.FFmpeg
             {
                 _FFmpegAudioSource.OnAudioSourceEncodedSample -= _FFmpegAudioSource_OnAudioSourceEncodedSample;
                 _FFmpegAudioSource.OnAudioSourceRawSample -= _FFmpegAudioSource_OnAudioSourceRawSample;
-                _FFmpegAudioSource.OnEndOfFile -= _FFmpegAudioSource_OnEndOfFile;
                 _FFmpegAudioSource.OnAudioSourceError -= _FFmpegAudioSource_OnAudioSourceError;
 
                 _FFmpegAudioSource.Dispose();
@@ -300,7 +284,6 @@ namespace SIPSorceryMedia.FFmpeg
             { 
                 _FFmpegVideoSource.OnVideoSourceEncodedSample -= _FFmpegVideoSource_OnVideoSourceEncodedSample;
                 _FFmpegVideoSource.OnVideoSourceRawSampleFaster -= _FFmpegVideoSource_OnVideoSourceRawSampleFaster;
-                _FFmpegVideoSource.OnEndOfFile -= _FFmpegVideoSource_OnEndOfFile;
                 _FFmpegVideoSource.OnVideoSourceError -= _FFmpegVideoSource_OnVideoSourceError;
 
                 _FFmpegVideoSource.Dispose();

--- a/src/FFmpegVideoDecoder.cs
+++ b/src/FFmpegVideoDecoder.cs
@@ -323,13 +323,7 @@ namespace SIPSorceryMedia.FFmpeg
                         }
                         else
                         {
-                            if (_isCamera)
-                            {
-                                RaiseError("Cannot read more frame");
-                                return;
-                            }
-                            else
-                                OnEndOfFile?.Invoke();
+                            OnEndOfFile?.Invoke();
                         }
                     }
                 }

--- a/src/SIPSorceryMedia.FFmpeg.csproj
+++ b/src/SIPSorceryMedia.FFmpeg.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.2</Version>
+    <Version>1.2.1</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>

--- a/test/FFmpegFileAndDevicesTest/Program.cs
+++ b/test/FFmpegFileAndDevicesTest/Program.cs
@@ -140,7 +140,8 @@ namespace FFmpegFileAndDevicesTest
                     if ((AudioSourceType == AUDIO_SOURCE.FILE_OR_STREAM)  && (AudioSourceFile == VideoSourceFile))
                     {
                         SIPSorceryMedia.FFmpeg.FFmpegFileSource fileSource = new SIPSorceryMedia.FFmpeg.FFmpegFileSource(VideoSourceFile, RepeatVideoFile, new AudioEncoder(), 960, true);
-                        fileSource.OnEndOfFile += () => PeerConnection.Close("source eof");
+                        fileSource.OnAudioSourceError += (msg) => PeerConnection.Close(msg);
+                        fileSource.OnVideoSourceError += (msg) => PeerConnection.Close(msg);
 
                         videoSource = fileSource as IVideoSource;
                         audioSource = fileSource as IAudioSource;
@@ -148,7 +149,7 @@ namespace FFmpegFileAndDevicesTest
                     else
                     {
                         SIPSorceryMedia.FFmpeg.FFmpegFileSource fileSource = new SIPSorceryMedia.FFmpeg.FFmpegFileSource(VideoSourceFile, RepeatVideoFile, new AudioEncoder(), 960, true);
-                        fileSource.OnEndOfFile += () => PeerConnection.Close("source eof");
+                        fileSource.OnVideoSourceError += (msg) => PeerConnection.Close(msg);
 
                         videoSource = fileSource as IVideoSource;
                     }
@@ -164,7 +165,10 @@ namespace FFmpegFileAndDevicesTest
                         camera = cameras.Last();
                     }
                     if (camera != null)
+                    {
                         videoSource = new SIPSorceryMedia.FFmpeg.FFmpegCameraSource(camera.Path);
+                        videoSource.OnVideoSourceError += (msg) => PeerConnection.Close(msg);
+                    }
                     else
                         throw new NotSupportedException($"Cannot find adequate camera ...");
                     
@@ -187,8 +191,11 @@ namespace FFmpegFileAndDevicesTest
                             primaryMonitor = monitors[0];
                     }
 
-                    if(primaryMonitor != null)
+                    if (primaryMonitor != null)
+                    {
                         videoSource = new SIPSorceryMedia.FFmpeg.FFmpegScreenSource(primaryMonitor.Path, primaryMonitor.Rect, 10);
+                        videoSource.OnVideoSourceError += (msg) => PeerConnection.Close(msg);
+                    }
                     else
                         throw new NotSupportedException($"Cannot find adequate monitor ...");
                     break;
@@ -200,7 +207,7 @@ namespace FFmpegFileAndDevicesTest
                 {
                     case AUDIO_SOURCE.FILE_OR_STREAM:
                         SIPSorceryMedia.FFmpeg.FFmpegFileSource fileSource = new SIPSorceryMedia.FFmpeg.FFmpegFileSource(AudioSourceFile, RepeatAudioFile, new AudioEncoder(), 960, false);
-                        fileSource.OnEndOfFile += () => PeerConnection.Close("source eof");
+                        fileSource.OnAudioSourceError += (msg) => PeerConnection.Close(msg);
 
                         audioSource = fileSource as IAudioSource;
                         break;


### PR DESCRIPTION
Remove event **OnEndOfFile** in **AudioSource, FileSource** and **VideoSource**.
Use instead **OnAudioSourceError** or **OnVideoSourceError**.

**The goal is to be coherent when a source is not accessible OR no more accessible.**
The source is no more accessible when the device in use is unplugged for example or if the file (remote/local) is no more accessible (network trouble, ...)

FFmpeg raises an error when a source is not accessible (so in initialization step) but it raises EOF when it's no more accessible ...

On a file device if the "loop" option is used, error event is not triggered immediately on EOF. Because it's not possible to know is EOF is really reached or if the file is no more accessible. The init step is started and if it fails the error event if raised
