### PR TITLE
Initialise: set logger before registering binaries

### DIFF
--- a/src/FfmpegInit.cs
+++ b/src/FfmpegInit.cs
@@ -75,12 +75,12 @@ namespace SIPSorceryMedia.FFmpeg
 
         public static void Initialise(FfmpegLogLevelEnum? logLevel = null, String? libPath = null, ILogger? appLogger = null)
         {
-            RegisterFFmpegBinaries(libPath);
-
             if (appLogger != null)
             {
                 logger = appLogger;
             }
+
+            RegisterFFmpegBinaries(libPath);
 
             logger.LogInformation($"FFmpeg version info: {ffmpeg.av_version_info()}");
 


### PR DESCRIPTION
Logger was set too late so any logs by `RegisterFFmpegBinaries` went straight to `Null`