### PR TITLE
Improved `Dispose` implementations

### DIFF
--- a/src/FFmpegVideoSource.cs
+++ b/src/FFmpegVideoSource.cs
@@ -247,6 +247,9 @@ namespace SIPSorceryMedia.FFmpeg
                 _videoEncoder.Dispose();
                 _videoEncoder = null;
             }
+
+            _videoFrameBGR24Converter?.Dispose();
+            _videoFrameYUV420PConverter?.Dispose();
         }
 
     }


### PR DESCRIPTION
`VideoFrameConverter`: object disposed checks; allow multiple calls to `Dispose` as required by `IDisposable` contract

`FFmpegVideoSource`: dispose internal frame converters