### PR TITLE
Enable encoder options in FFMpegVideoEndPoint

### DIFF
--- a/src/FFmpegVideoEndPoint.cs
+++ b/src/FFmpegVideoEndPoint.cs
@@ -35,10 +35,10 @@ namespace SIPSorceryMedia.FFmpeg
         //public event SourceErrorDelegate? OnVideoSourceError;
 #pragma warning restore CS0067
 
-        public FFmpegVideoEndPoint()
+        public FFmpegVideoEndPoint(Dictionary<string, string>? encoderOptions = null)
         {
             _videoFormatManager = new MediaFormatManager<VideoFormat>(_supportedFormats);
-            _ffmpegEncoder = new FFmpegVideoEncoder();
+            _ffmpegEncoder = new FFmpegVideoEncoder(encoderOptions);
         }
 
         public MediaEndPoints ToMediaEndPoints()


### PR DESCRIPTION
It's possible to set options on the encoder, but there's no way to do so through the FFMpegVideoEndpoint. This PR enables that.