### PR TITLE
Enable hardware acceleration for decoding.

### DIFF
--- a/src/FFmpegVideoEncoder.cs
+++ b/src/FFmpegVideoEncoder.cs
@@ -491,7 +491,7 @@ namespace SIPSorceryMedia.FFmpeg
                             rgbFrames.Add(imageRawSample);
                         }
 
-                        recvRes = ffmpeg.avcodec_receive_frame(_decoderContext, decodedFrame);
+                        recvRes = ffmpeg.avcodec_receive_frame(_decoderContext, frame);
                     }
 
                     if (recvRes < 0 && recvRes != ffmpeg.AVERROR(ffmpeg.EAGAIN))

--- a/src/FFmpegVideoEncoder.cs
+++ b/src/FFmpegVideoEncoder.cs
@@ -22,8 +22,8 @@ namespace SIPSorceryMedia.FFmpeg
         private AVCodecContext* _decoderContext;
         private AVCodecID _codecID;
         private AVHWDeviceType _HwDeviceType;
-        AVFrame* _frame;
-        AVFrame* _gpuFrame;
+        private AVFrame* _frame;
+        private AVFrame* _gpuFrame;
 
         private VideoFrameConverter? _encoderPixelConverter;
         private VideoFrameConverter? _i420ToRgb;
@@ -174,13 +174,13 @@ namespace SIPSorceryMedia.FFmpeg
                 {
                     ffmpeg.av_opt_set(_encoderContext->priv_data, "quality", "realtime", 0).ThrowExceptionIfError();
                 }
-                
+
                 foreach (var option in _encoderOptions)
                 {
                     ffmpeg.av_opt_set(_encoderContext->priv_data, option.Key, option.Value, 0).ThrowExceptionIfError();
                 }
 
-                
+
                 ffmpeg.avcodec_open2(_encoderContext, codec, null).ThrowExceptionIfError();
 
 
@@ -382,7 +382,7 @@ namespace SIPSorceryMedia.FFmpeg
 
         public List<RawImage>? DecodeFaster(AVCodecID codecID, byte[] buffer, out int width, out int height)
         {
-            if ( (!_isDisposed) && (buffer != null))
+            if ((!_isDisposed) && (buffer != null))
             {
                 lock (_decoderLock)
                 {
@@ -428,7 +428,7 @@ namespace SIPSorceryMedia.FFmpeg
                 }
 
                 List<RawImage> rgbFrames = new List<RawImage>();
-                if( ffmpeg.avcodec_send_packet(_decoderContext, packet) < 0 )
+                if (ffmpeg.avcodec_send_packet(_decoderContext, packet) < 0)
                 {
                     width = height = 0;
                     return null;
@@ -442,7 +442,7 @@ namespace SIPSorceryMedia.FFmpeg
                 {
 
                     AVFrame* decodedFrame = _frame;
-                    if(_decoderContext->hw_device_ctx != null)
+                    if (_decoderContext->hw_device_ctx != null)
                     {
                         // If this is hw accelerated, the data in `frame` resides in the GPU memory
                         // Copy it to the CPU memory (gpuFrame)
@@ -502,7 +502,7 @@ namespace SIPSorceryMedia.FFmpeg
                 }
 
                 return rgbFrames;
-                
+
             }
             else
             {
@@ -535,13 +535,15 @@ namespace SIPSorceryMedia.FFmpeg
                     }
                 }
 
-                if(_frame != null) {
-                    fixed ( AVFrame** pFrame = &_frame) { 
-                    ffmpeg.av_frame_free(pFrame);
+                if (_frame != null)
+                {
+                    fixed (AVFrame** pFrame = &_frame)
+                    {
+                        ffmpeg.av_frame_free(pFrame);
                     }
                 }
-                
-                if(_gpuFrame != null)
+
+                if (_gpuFrame != null)
                 {
                     fixed (AVFrame** pFrame = &_gpuFrame)
                     {


### PR DESCRIPTION
The following code prints out the available HW accelerated decoders:
```
var type = AVHWDeviceType.AV_HWDEVICE_TYPE_NONE;
while((type = ffmpeg.av_hwdevice_iterate_types(type)) != AVHWDeviceType.AV_HWDEVICE_TYPE_NONE)
{
    Console.WriteLine($"{type}");
}
```

Providing one of these types in the constructor will enable HW accelerated decoding.

This however means that the user is explicitly interfacing with the FFMPEG package, rather than a wrapper version. However, for an initial version I think that's probably fine, compared to how great it would be to be able to do hardware accelerated decoding :)