### PR TITLE
Updated to use FFMPEG version 6 libraries through reference to FFmpegAutoGen package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ There is no **Audio ouput** in this library. For this you can use [SIPSorcery.SD
 
 ## For Windows
 
-No additional steps are required for an x64 build. The nuget package includes the [FFmpeg](https://www.ffmpeg.org/) x64 binaries.
+Install the [FFmpeg](https://www.ffmpeg.org/) binaries using the packages at https://www.gyan.dev/ffmpeg/builds/#release-builds and include the FFMPEG executable in your PATH to find them automatically.
 
 ## For Linux
 

--- a/src/FFmpegAudioDecoder.cs
+++ b/src/FFmpegAudioDecoder.cs
@@ -137,7 +137,7 @@ namespace SIPSorceryMedia.FFmpeg
                 }
                 else
                     ffmpeg.av_opt_set_channel_layout(_swrContext, "in_channel_layout", (long)_audDecCtx->channel_layout, 0);
-                ffmpeg.av_opt_set_channel_layout(_swrContext, "out_channel_layout", ffmpeg.AV_CH_LAYOUT_MONO, 0);
+                ffmpeg.av_opt_set_channel_layout(_swrContext, "out_channel_layout", (long)ffmpeg.AV_CH_LAYOUT_MONO, 0);
 
                 if ( ffmpeg.swr_init(_swrContext) < 0 )
                 {

--- a/src/SIPSorceryMedia.FFmpeg.csproj
+++ b/src/SIPSorceryMedia.FFmpeg.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.2.1</Version>
+    <Version>1.3.0-pre</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
@@ -26,7 +26,7 @@
     <PackageReference Include="DirectShowLib.Standard" Version="2.1.0" />
     <PackageReference Include="SIPSorceryMedia.Abstractions" Version="1.2.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-    <PackageReference Include="FFmpeg.AutoGen" Version="4.4.1.1" />
+    <PackageReference Include="FFmpeg.AutoGen" Version="6.0.0.2" />
   </ItemGroup>
   
 

--- a/test/FFmpegConsoleApp/FFmpegConsoleApp.csproj
+++ b/test/FFmpegConsoleApp/FFmpegConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/FFmpegConsoleApp/Program.cs
+++ b/test/FFmpegConsoleApp/Program.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using FFmpeg.AutoGen;
 using SIPSorceryMedia.Abstractions;
 using SIPSorceryMedia.FFmpeg;
 
@@ -10,11 +7,6 @@ namespace FFmpegConsoleApp
 {
     class Program
     {
-        // /!\ It's MANDATORY to specify a valid path where FFmpeg binaries / libraries ae stored
-        private const string LIB_PATH = @"C:\ffmpeg-4.4.1-full_build-shared\bin";
-        //private const string LIB_PATH = @"/usr/local/Cellar/ffmpeg/4.4.1_5/lib";
-        //private const string LIB_PATH = @"..\..\..\..\..\lib\x64";
-
         // A valid to a video file - usefull if you want to test streaming of a video file
         // It's alo possible to set a remote file
         const String VIDEO_FILE_PATH = @"https://upload.wikimedia.org/wikipedia/commons/3/36/Cosmos_Laundromat_-_First_Cycle_-_Official_Blender_Foundation_release.webm"; 
@@ -30,7 +22,7 @@ namespace FFmpegConsoleApp
             IVideoSource? videoSource = null;
 
             // Initialise FFmpeg librairies
-            FFmpegInit.Initialise(FfmpegLogLevelEnum.AV_LOG_FATAL, LIB_PATH);
+            FFmpegInit.Initialise(FfmpegLogLevelEnum.AV_LOG_FATAL);
 
             // Get cameras and monitors
             List<Camera>? cameras = FFmpegCameraManager.GetCameraDevices();

--- a/test/FFmpegEncodingTest/FFmpegEncodingTest.csproj
+++ b/test/FFmpegEncodingTest/FFmpegEncodingTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/test/FFmpegWebRtcReceiver/FFmpegWebRTCReceiver.csproj
+++ b/test/FFmpegWebRtcReceiver/FFmpegWebRTCReceiver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <DisableWinExeOutputInference>true</DisableWinExeOutputInference>
   </PropertyGroup>
@@ -18,7 +18,7 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="SIPSorcery" Version="6.0.4" />
     <PackageReference Include="SIPSorcery.WebSocketSharp" Version="0.0.1" />
-    <PackageReference Include="SIPSorceryMedia.Encoders" Version="0.0.10-pre" />
+    <PackageReference Include="SIPSorceryMedia.Encoders" Version="0.0.12-pre" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/FFmpegWebRtcReceiver/Program.cs
+++ b/test/FFmpegWebRtcReceiver/Program.cs
@@ -28,10 +28,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Serilog;
 using Serilog.Extensions.Logging;
-using SIPSorcery.Media;
 using SIPSorcery.Net;
 using SIPSorceryMedia.Abstractions;
-using SIPSorceryMedia.Encoders;
 using SIPSorceryMedia.FFmpeg;
 using WebSocketSharp.Server;
 
@@ -74,6 +72,9 @@ namespace demo
             var parseResult = Parser.Default.ParseArguments<Options>(args);
             _options = (parseResult as Parsed<Options>)?.Value;
             X509Certificate2 wssCertificate = (_options.WSSCertificate != null) ? LoadCertificate(_options.WSSCertificate) : null;
+
+            // Initialise FFmpeg librairies
+            FFmpegInit.Initialise(FfmpegLogLevelEnum.AV_LOG_FATAL);
 
             // Start web socket.
             Console.WriteLine("Starting web socket server...");


### PR DESCRIPTION
I would like to note that I tried to update the reference to SIPSorcery in the FFmpegWebWRTCReceiver but if I went any higher than 6.0.4 I got errors about decoding.

Also included these updates:
- Change some test programs to run under .NET 6.0
- Update README to indicate that FFMPEG binaries are not included with Windows
- Look in system PATH for the FFMPEG binaries
- Throw exception if binary path not found by any method