### PR TITLE
Enable generation of SIPSorceryMedia.FFmpeg.xml documentation file

### DIFF
--- a/src/SIPSorceryMedia.FFmpeg.csproj
+++ b/src/SIPSorceryMedia.FFmpeg.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -6,6 +6,9 @@
     <LangVersion>preview</LangVersion>
     <PackageLicenseExpression>LGPL-2.1-only</PackageLicenseExpression>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- Disable warning for missing XML doc comments. -->
+    <NoWarn>$(NoWarn);CS1591;CS1573</NoWarn>
   </PropertyGroup>
  
   <ItemGroup>


### PR DESCRIPTION
Same thing as https://github.com/sipsorcery-org/sipsorcery/pull/1106. I know there isn't very many of doccomments in this project, but still better than none ;)