### PR TITLE
Camera-specific Settings (Rsolution, FPS, & Oth. Decoder Options) for DirectShow

### DIFF
--- a/src/FFmpegCameraManager.cs
+++ b/src/FFmpegCameraManager.cs
@@ -77,9 +77,21 @@ namespace SIPSorceryMedia.FFmpeg
 
     public class Camera
     {
-        public String Name { get; set; }
+        public struct CameraFormat
+        {
+            public AVPixelFormat PixelFormat;
+            public int Width;
+            public int Height;
+            public double FPS;
+        }
 
-        public String Path { get; set; }
+        public string Name { get; set; }
+
+        public string Path { get; set; }
+
+        public List<CameraFormat>? AvailableFormats {  get; set; }
+
+        public List<Dictionary<string, string>>? AvailableOptions { get; set; }
 
         public Camera()
         {

--- a/src/FFmpegCameraManager.cs
+++ b/src/FFmpegCameraManager.cs
@@ -18,26 +18,10 @@ namespace SIPSorceryMedia.FFmpeg
                                     : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "avfoundation"
                                     : throw new NotSupportedException($"Cannot find adequate input format - OSArchitecture:[{RuntimeInformation.OSArchitecture}] - OSDescription:[{RuntimeInformation.OSDescription}]");
 
-
-            // FFmpeg doesn't implement avdevice_list_input_sources() for the DShow input format yet.
             if (inputFormat == "dshow")
             {
-                result = new List<Camera>();
-                var dsDevices = DsDevice.GetDevicesOfCat(FilterCategory.VideoInputDevice);
-                for (int i = 0; i < dsDevices.Length; i++)
-                {
-                    var dsDevice = dsDevices[i];
-                    if ((dsDevice.Name != null) && (dsDevice.Name.Length > 0))
-                    {
-                        Camera camera = new Camera
-                        {
-                            Name = dsDevice.Name,
-                            Path = $"video={dsDevice.Name}"
-                        };
-                        result.Add(camera);
+                result = SIPSorceryMedia.FFmpeg.Interop.Win32.DShow.GetCameraDevices();
                     }
-                }
-            }
             else if (inputFormat == "avfoundation")
             {
                 result = SIPSorceryMedia.FFmpeg.Interop.MacOS.AvFoundation.GetCameraDevices();

--- a/src/FFmpegCameraManager.cs
+++ b/src/FFmpegCameraManager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
 using DirectShowLib;
+using System.Linq;
 
 namespace SIPSorceryMedia.FFmpeg
 {
@@ -80,6 +81,24 @@ namespace SIPSorceryMedia.FFmpeg
         public Camera()
         {
             Name = Path = "";
+        }
+    }
+
+    internal class CameraEqualityComparer : EqualityComparer<Camera>
+    {
+        new public static CameraEqualityComparer Default = new();
+
+        public override bool Equals(Camera? x, Camera? y)
+        {
+            return x != null && y != null && x.Name == y.Name && x.Path == y.Path
+                && !string.IsNullOrEmpty(x.Name) && !string.IsNullOrEmpty(y.Name)
+                && !string.IsNullOrEmpty(x.Path) && !string.IsNullOrEmpty(y.Path)
+                ;
+        }
+
+        public override int GetHashCode(Camera obj)
+        {
+            return obj.GetHashCode();
         }
     }
 }

--- a/src/FFmpegCameraManager.cs
+++ b/src/FFmpegCameraManager.cs
@@ -58,6 +58,8 @@ namespace SIPSorceryMedia.FFmpeg
             }
             return result;
         }
+
+        static public Camera? GetCameraByPath(string path) => GetCameraDevices()?.FirstOrDefault(x => x.Path == path);
     }
 
     public class Camera

--- a/src/FFmpegCameraManager.cs
+++ b/src/FFmpegCameraManager.cs
@@ -22,7 +22,7 @@ namespace SIPSorceryMedia.FFmpeg
             if (inputFormat == "dshow")
             {
                 result = SIPSorceryMedia.FFmpeg.Interop.Win32.DShow.GetCameraDevices();
-                    }
+            }
             else if (inputFormat == "avfoundation")
             {
                 result = SIPSorceryMedia.FFmpeg.Interop.MacOS.AvFoundation.GetCameraDevices();
@@ -84,23 +84,16 @@ namespace SIPSorceryMedia.FFmpeg
         {
             Name = Path = "";
         }
-    }
 
-    internal class CameraEqualityComparer : EqualityComparer<Camera>
-    {
-        new public static CameraEqualityComparer Default = new();
-
-        public override bool Equals(Camera? x, Camera? y)
+        public override bool Equals(object? obj)
         {
-            return x != null && y != null && x.Name == y.Name && x.Path == y.Path
-                && !string.IsNullOrEmpty(x.Name) && !string.IsNullOrEmpty(y.Name)
-                && !string.IsNullOrEmpty(x.Path) && !string.IsNullOrEmpty(y.Path)
-                ;
+            return obj is not null && obj.GetType() == GetType()
+                && ((Camera)obj).Name == Name && ((Camera)obj).Path == Path;
         }
 
-        public override int GetHashCode(Camera obj)
+        public override int GetHashCode()
         {
-            return obj.GetHashCode();
+            return Name.GetHashCode();
         }
     }
 }

--- a/src/FFmpegCameraSource.cs
+++ b/src/FFmpegCameraSource.cs
@@ -60,6 +60,7 @@ namespace SIPSorceryMedia.FFmpeg
                                     .ThenByDescending(c => c.FPS)
                                     .Select(c => new Dictionary<string, string>()
                                     {
+                                        { "pixel_format", ffmpeg.av_get_pix_fmt_name(c.PixelFormat) },
                                         { "video_size", $"{c.Width}x{c.Height}" },
                                         { "framerate", $"{c.FPS}" },
                                     })

--- a/src/FFmpegCameraSource.cs
+++ b/src/FFmpegCameraSource.cs
@@ -1,30 +1,115 @@
 ﻿using FFmpeg.AutoGen;
 using Microsoft.Extensions.Logging;
+using SIPSorcery;
 using SIPSorceryMedia.Abstractions;
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace SIPSorceryMedia.FFmpeg
 {
-    public class FFmpegCameraSource : FFmpegVideoSource
+    public unsafe class FFmpegCameraSource : FFmpegVideoSource
     {
-        private static ILogger logger = SIPSorcery.LogFactory.CreateLogger<FFmpegCameraSource>();
+        private static ILogger logger = LogFactory.CreateLogger<FFmpegCameraSource>();
 
-        public unsafe FFmpegCameraSource(string path)
+        private readonly AVInputFormat* _aVInputFormat;
+        private readonly Camera _camera;
+
+        /// <summary>
+        /// Construct an FFmpeg camera/input device source provided input path.
+        /// </summary>
+        /// <remarks>See </remarks>
+        /// <param name="path"></param>
+        public FFmpegCameraSource(string path) : this(FFmpegCameraManager.GetCameraByPath(path) ?? new() { Path = path })
         {
+        }
+
+        public unsafe FFmpegCameraSource(Camera camera)
+        {
+            _camera = camera;
+
             string inputFormat = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dshow"
                                     : RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "v4l2"
                                     : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "avfoundation"
-                                    : throw new NotSupportedException($"Cannot find adequate input format - OSArchitecture:[{RuntimeInformation.OSArchitecture}] - OSDescription:[{RuntimeInformation.OSDescription}]");
+                                    : throw new NotSupportedException($"Cannot find adequate input format" +
+                                                $" - OSArchitecture:[{RuntimeInformation.OSArchitecture}]" +
+                                                $" - OSDescription:[{RuntimeInformation.OSDescription}]");
 
-            AVInputFormat* aVInputFormat = ffmpeg.av_find_input_format(inputFormat);
+            _aVInputFormat = ffmpeg.av_find_input_format(inputFormat);
 
-            CreateVideoDecoder(path, aVInputFormat, false, true);
+            CreateVideoDecoder(_camera.Path, _aVInputFormat, false, true);
 
             InitialiseDecoder();
+        }
+
+        /// <summary>
+        /// Filter for the desired <see cref="Camera.CameraFormat"/>(s) to use
+        /// and resets the underlying <see cref="FFmpegVideoDecoder"/>.
+        /// </summary>
+        /// <remarks>Will use highest resolution and framerate after filtered.
+        /// </remarks>
+        /// <param name="formatFilter">Filter function.</param>
+        public void RestrictCameraFormats(Predicate<Camera.CameraFormat> formatFilter)
+        {
+            var maxAllowedres = _camera.AvailableFormats?.Where(formatFilter.Invoke)
+                                    .OrderByDescending(c => c.Width > c.Height ? c.Width : c.Height)
+                                    .ThenByDescending(c => c.FPS)
+                                    .Select(c => new Dictionary<string, string>()
+                                    {
+                                        { "video_size", $"{c.Width}x{c.Height}" },
+                                        { "framerate", $"{c.FPS}" },
+                                    })
+                                    .FirstOrDefault();
+            
+            if(maxAllowedres is null)
+                logger.LogWarning($"camera/input device \"{_camera.Name}\" doesn't have any recognizable formats to be used.");
+
+            SetCameraDeviceOptions(maxAllowedres);
+        }
+
+        /// <summary>
+        /// Filter for available FFmpeg camera/input device options and resets the underlying
+        /// <see cref="FFmpegVideoDecoder"/> with the specified options.
+        /// </summary>
+        /// <remarks>
+        /// <i>This is an advanced control for camera/input devices options filtering.
+        /// <br/>Most usage will use <see cref="RestrictCameraFormats"/> filter.</i>
+        /// <br/><br/> See <see href="https://www.ffmpeg.org/ffmpeg-devices.html">FFmpeg documentation on the device options</see>
+        /// for your system's <see cref="AVInputFormat"/> (i.e. dshow, avfoundation, v4l2, etc.)
+        /// </remarks>
+        /// <param name="optFilter">Filter function.</param>
+        public void RestrictCameraOptions(Predicate<Dictionary<string, string>> optFilter)
+        {
+            var opts = _camera.AvailableOptions?.FirstOrDefault(optFilter.Invoke);
+
+            if (opts is null)
+                logger.LogWarning($"No camera/input device options to be used.");
+
+            SetCameraDeviceOptions(opts);
+        }
+
+        /// <summary>
+        /// Resets the underlying <see cref="FFmpegVideoDecoder"/> with the provided options.
+        /// </summary>
+        /// <remarks>
+        /// <br/><i>This is an advanced options for if you know/static preconfigured device options beforehand.
+        /// Most usage will use <see cref="RestrictCameraFormats"/> or <see cref="RestrictCameraOptions"/> filter.</i>
+        /// <br/><br/>
+        /// See <see href="https://www.ffmpeg.org/ffmpeg-devices.html">FFmpeg documentation on the device options</see>
+        /// for your system's <see cref="AVInputFormat"/> (i.e. dshow, avfoundation, v4l2, etc.)
+        /// </remarks>
+        /// <param name="options">A dictionary of device options</param>
+        public void SetCameraDeviceOptions(Dictionary<string, string>? options)
+        {
+            _videoDecoder?.Dispose();
+
+            CreateVideoDecoder(_camera.Path, _aVInputFormat, false, true);
+
+            InitialiseDecoder(options);
         }
     }
 }

--- a/src/Interop/Win32/DShow.cs
+++ b/src/Interop/Win32/DShow.cs
@@ -1,0 +1,134 @@
+using FFmpeg.AutoGen;
+using SIPSorceryMedia.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace SIPSorceryMedia.FFmpeg.Interop.Win32
+{
+    internal class DShow
+    {
+        const string inputfmt = nameof(DShow);
+
+        static private string[] DSHOW_VIDEO_DEVICE_LOG_OUTPUT = ["(video)", "camera", "webcam"];
+        static private string DSHOW_AUDIO_DEVICE_LOG_OUTPUT = "(audio)";
+
+        static private string[] DSHOW_CAMERA_FORMAT_LOG_OUTPUT = ["pixel_format"];
+
+        /// <summary>
+        /// Gets all DirectShow camera and input devices.
+        /// </summary>
+        /// <returns>a <see cref="List{T}"/> of <see cref="Camera"/>s found on the system.</returns>
+        public static List<Camera>? GetCameraDevices()
+            => ParseDShowLogsForCameras(GetDShowLogsForDevice())?.ToList();
+
+        private static List<Camera>? ParseDShowLogsForCameras(string? logs)
+        {
+            return logs?.Split(["\r\n", "\r", "\n"], StringSplitOptions.RemoveEmptyEntries)
+                .Where(l => DSHOW_VIDEO_DEVICE_LOG_OUTPUT.Any(l.ToLower().Contains))
+                .Select(l =>
+                {
+                    var cam = l.Split(['"'], StringSplitOptions.RemoveEmptyEntries).First();
+
+                    var opts = GetDShowLogsForDevice(cam)?
+                            .Split(["\r\n", "\r", "\n"], StringSplitOptions.RemoveEmptyEntries)
+                            .Where(l => DSHOW_CAMERA_FORMAT_LOG_OUTPUT.Any(l.ToLower().Contains))
+                            .Select(l =>
+                            {
+                                var grouped = l.Split([' '], StringSplitOptions.RemoveEmptyEntries)
+                                    .Where(s => s.Contains("="))
+                                    .Distinct()
+                                    .Select(s => s.Split(['='], StringSplitOptions.RemoveEmptyEntries))
+                                    .Select(kp => new KeyValuePair<string, string>(value: kp[1],
+                                                    key: kp[0] switch
+                                                    {
+                                                        "fps" => "framerate",
+                                                        "s" => "video_size",
+                                                        _ => kp[0]
+                                                    }))
+                                    .GroupBy(kp => kp.Key)
+                                    .ToDictionary(g => g.Key, g => g.Select(kvp => kvp.Value));
+
+                                return Enumerable.Range(0, grouped.Values.Max(v => v.Count()))
+                                    .Select(i => grouped.ToDictionary(
+                                        g => g.Key,
+                                        g => g.Value.ElementAtOrDefault(i) ?? g.Value.Last()))
+                                    ;
+                            })
+                            .SelectMany(ld => ld)
+                            .ToList();
+
+                    return new Camera()
+                    {
+                        Name = cam, Path = $"video={cam}",
+                        AvailableOptions = opts,
+                        AvailableFormats = opts?
+                            .Select(d =>
+                            {
+                                return new Camera.CameraFormat()
+                                {
+                                    PixelFormat = ffmpeg.av_get_pix_fmt(d[d.Keys.First(DSHOW_CAMERA_FORMAT_LOG_OUTPUT.Contains)]),
+                                    Width = int.Parse(d["video_size"].Split(['x'], StringSplitOptions.RemoveEmptyEntries)[0]),
+                                    Height = int.Parse(d["video_size"].Split(['x'], StringSplitOptions.RemoveEmptyEntries)[1]),
+                                    FPS = double.Parse(d["framerate"])
+                                };
+                            })
+                            .ToList()
+                    };
+
+                })
+                .ToList();
+        }
+
+        private static unsafe string? GetDShowLogsForDevice(string? name = null)
+        {
+            AVInputFormat* avInputFormat = ffmpeg.av_find_input_format(inputfmt.ToLower());
+            AVFormatContext* pFormatCtx = ffmpeg.avformat_alloc_context();
+            AVDictionary* options = null;
+
+            ffmpeg.av_dict_set(&options, string.IsNullOrEmpty(name) ? "list_devices" : "list_options", "true", 0);
+
+            UseSpecificLogCallback();
+
+            ffmpeg.avformat_open_input(&pFormatCtx, string.IsNullOrEmpty(name) ? null : $"video={name}", avInputFormat, &options); // Here nb is < 0 ... But we have anyway an output from av_log which can be parsed ...
+            ffmpeg.avformat_close_input(&pFormatCtx);
+
+            // We no more need to use temporarily a specific callback to log FFmpeg entries
+            FFmpegInit.UseDefaultLogCallback();
+
+            // returns logs 
+            return storedLogs;
+        }
+
+        static string? storedLogs;
+
+        private static unsafe void UseSpecificLogCallback()
+        {
+            // We clear previous stored logs
+            if (!string.IsNullOrEmpty(storedLogs))
+                storedLogs = string.Empty;
+
+            av_log_set_callback_callback logCallback = (p0, level, format, vl) =>
+            {
+                if (level > ffmpeg.av_log_get_level()) return;
+
+                var lineSize = 4096;
+                var lineBuffer = stackalloc byte[lineSize];
+                var printPrefix = 0;
+                
+                var num = ffmpeg.av_log_format_line2(p0, level, format, vl, lineBuffer, lineSize, &printPrefix);
+
+                var line = Encoding.Default.GetString(lineBuffer, num);
+                Console.Write(line);
+                storedLogs += line;
+            };
+            ffmpeg.av_log_set_callback(logCallback);
+        }
+
+    }
+}

--- a/src/Interop/Win32/DShow.cs
+++ b/src/Interop/Win32/DShow.cs
@@ -33,7 +33,7 @@ namespace SIPSorceryMedia.FFmpeg.Interop.Win32
             // Get DShowLib cameras in case of something wrong.
             var dshowcams = GetDShowLibCameras();
 
-            return (ffmpegcams?.Union(dshowcams ?? Enumerable.Empty<Camera>(), CameraEqualityComparer.Default) ?? dshowcams)?.ToList();
+            return (ffmpegcams?.Union(dshowcams ?? Enumerable.Empty<Camera>()) ?? dshowcams)?.ToList();
         }
 
         private static List<Camera>? ParseDShowLogsForCameras(string? logs)
@@ -45,15 +45,15 @@ namespace SIPSorceryMedia.FFmpeg.Interop.Win32
                     var cam = splitline.Split(['"'], StringSplitOptions.RemoveEmptyEntries).First();
 
                     var opts = GetDShowLogsForDevice(cam)?
-                            .Split(["\r\n", "\r", "\n"], StringSplitOptions.RemoveEmptyEntries)
-                                    .Where(s => s.Contains("="))
+                        .Split(["\r\n", "\r", "\n"], StringSplitOptions.RemoveEmptyEntries)
+                        .Where(s => s.Contains("="))
                         .Select(optline =>
                             optline.Split(["min", "max"], StringSplitOptions.RemoveEmptyEntries)
                             .Select((sections, i) => sections
                                 .Split([' '], StringSplitOptions.RemoveEmptyEntries)
                                 .Where(s => s.Contains("="))
                                 .Select(opt =>
-                                                    {
+                                {
                                     var kp = opt.Split(['='], StringSplitOptions.RemoveEmptyEntries);
 
                                     return string.IsNullOrEmpty(kp.ElementAtOrDefault(0))
@@ -70,7 +70,7 @@ namespace SIPSorceryMedia.FFmpeg.Interop.Win32
                                             }
                                             + kp.ElementAtOrDefault(0)!
                                         );
-                            })
+                                })
                                 .Where(kp => !string.IsNullOrEmpty(kp.Key))
                             )
                             .SelectMany(d => d)


### PR DESCRIPTION
May resolve #79.

### Summary:

- [x] **DirectShow** camera/input devices formats/options parsing from FFmpeg,
- [x] Camera settings (video resolution, framerates, & other decoder-related options), It is added as an additional functions instead of in the constructor for simplicity,
    - **(Simple)** Restricts filter for formats to be used (pixel_format, resolution, & fps),
    - **(Advanced)** Restricts filter for device options to be used (specific to the input format),
    - **(Pre-configured Advanced)** Sets the device options manually which usually is a preconfigured set of options (specific to the input format),
- [ ] Not yet tested for other input formats (avfoundation, v4l2, etc.), but they should be compatible by default.

A bit considerations:
- [ ] Caches the found cameras? Because the backward compatibility will need to re-parse the FFmpeg output. But unless the backward compatibility users spawn multiple camera sources in a loop as fast as possible, I don't think it's worth it,
- [ ] Though there is no confirmation on the actual resolution and framerate being used also no exception handle yet.

### Additions:
- New `Camera` properties
```c#
public class Camera
{
    // general purpose pixel_format structure
    public struct CameraFormat
    {
        public AVPixelFormat PixelFormat;
        public int Width;
        public int Height;
        public double FPS;
    }
    // formats from FFmpeg
    public List<CameraFormat>? AvailableFormats {  get; set; }

    // Other specific non-pixel_format (e.g. vcodec/etc.)
    public List<Dictionary<string, string>>? AvailableOptions { get; set; }
/// ... ///
}

```
- New methods & constructor to `FFmpegCameraSource` with `Camera`:
```c#
public unsafe class FFmpegCameraSource : FFmpegVideoSource
{
    // Cameras now have formats, so get the camera object instead of only the path
    public FFmpegCameraSource(Camera camera) { /// ... /// }

    // Backward compatibility for providing only path is to re-enumerate the cameras to get the corresponding camera
    // and fallback to just the path
    public FFmpegCameraSource(string path) : this(FFmpegCameraManager.GetCameraByPath(path) ?? new() { Path = path }) { /// ... /// }

// Simple, filter from the generally available rawvideo formats
public void RestrictCameraFormats(Predicate<Camera.CameraFormat> formatFilter) { /// ... /// }

// Advanced, filter from all available format options
public void RestrictCameraOptions(Predicate<Dictionary<string, string>> optFilter) { /// ... /// }
/// ... ///
}
/// ... ///
public unsafe class FFmpegCameraManager
{
    // re-parse FFmpeg camera devices to "reverse lookup" for a path
    static public Camera? GetCameraByPath(string path) => GetCameraDevices()?.FirstOrDefault(x => x.Path == path);
    /// ... ///
}
```
- New methods usage example
```c#
var localvid = new FFmpegCameraSource(FFmpegCameraManager.GetCameraDevices()!.First());
/// ... ///
// Simple, set the camera resolution to anything up to 480 with fps more than 15
localvid.RestrictCameraFormats(cam => cam.Width <= 480 && cam.Height <= 480 && cam.FPS >= 15);

// Advanced, set the decoder to use any vcodec=mjpeg option
localvid.RestrictCameraOptions(opts =>
{
    return opts.Keys.Contains("vcodec") && opts["vcodec"] == "mjpeg";
});

// Most advanced set the options manually, you probably know FFmpeg/libAV* enough to use this.
localvid.SetCameraDeviceOptions(new() { /// ... /// });
```