### PR TITLE
Fix binary location detection bug

### DIFF
--- a/src/FfmpegInit.cs
+++ b/src/FfmpegInit.cs
@@ -109,7 +109,7 @@ namespace SIPSorceryMedia.FFmpeg
                 // search the system path, handle with and without .exe extension
                 string ffmpegExecutable = "ffmpeg";
                 string? path = Environment.GetEnvironmentVariable("PATH")?
-                    .Split(';')
+                    .Split([';'], StringSplitOptions.RemoveEmptyEntries)
                     .Where(s => File.Exists(Path.Combine(s, ffmpegExecutable)) || File.Exists(Path.Combine(s, ffmpegExecutable  + ".exe")))
                     .FirstOrDefault();
 


### PR DESCRIPTION
Modified the PATH splitting logic to ignore empty entries by using StringSplitOptions.RemoveEmptyEntries when splitting the PATH environment variable. This prevents the code from incorrectly detecting FFmpeg in the current directory when there's a trailing semicolon in PATH.