### PR TITLE
Adds HEVC (H.265), use Dynamic ID for video codecs, and auto-detect decode video codecs.

### DIFF
--- a/src/FFmpegVideoEncoder.cs
+++ b/src/FFmpegVideoEncoder.cs
@@ -21,8 +21,8 @@ namespace SIPSorceryMedia.FFmpeg
         private readonly Dictionary<string, string> _codecOptions;
         private Dictionary<string, Dictionary<string, string>>? _codecOptionsByName;
 
-        private Stopwatch _frameTimer;
-        public event EventHandler<VideoEncoderStatistics> OnVideoEncoderStatistics;
+        private Stopwatch? _frameTimer;
+        public event EventHandler<VideoEncoderStatistics>? OnVideoEncoderStatistics;
 
         private AVCodecContext* _encoderContext;
         private AVCodecContext* _decoderContext;
@@ -402,8 +402,7 @@ namespace SIPSorceryMedia.FFmpeg
                 _isDecoderInitialised = true;
                 _codecID = codecID;
 
-                //var codec = GetCodec(codecID, isEncoder: false); // not ready for decoder
-                var codec = ffmpeg.avcodec_find_decoder(codecID);
+                var codec = GetCodec(codecID, isEncoder: false);
                 var decOpts = GetCodecOptions(GetNameString(codec->name));
 
                 if (codec == null)
@@ -765,7 +764,6 @@ namespace SIPSorceryMedia.FFmpeg
 
                 while (recvRes == 0)
                 {
-
                     AVFrame* decodedFrame = _frame;
                     if (_decoderContext->hw_device_ctx != null)
                     {

--- a/src/FFmpegVideoEncoder.cs
+++ b/src/FFmpegVideoEncoder.cs
@@ -275,48 +275,44 @@ namespace SIPSorceryMedia.FFmpeg
                 else
                     _encoderContext->gop_size = fps;
 
-                // provide tunings for known codecs
-                switch (cdcname)
+                try
                 {
-                    case "libx264":
-                        ffmpeg.av_opt_set(_encoderContext->priv_data, "profile", "baseline", 0).ThrowExceptionIfError();
-                        ffmpeg.av_opt_set(_encoderContext->priv_data, "tune", "zerolatency", 0).ThrowExceptionIfError();
-                        break;
-                    case "h264_qsv":
-                        ffmpeg.av_opt_set(_encoderContext->priv_data, "profile", "66" /* baseline */, 0).ThrowExceptionIfError();
-                        ffmpeg.av_opt_set(_encoderContext->priv_data, "preset", "7" /* veryfast */, 0).ThrowExceptionIfError();
-                        break;
-                    case "libvpx":
-                        ffmpeg.av_opt_set(_encoderContext->priv_data, "quality", "realtime", 0).ThrowExceptionIfError();
-                        break;
-                    case "libx265":
-                        ffmpeg.av_opt_set(_encoderContext->priv_data, "preset", "ultrafast", 0).ThrowExceptionIfError();
-                        ffmpeg.av_opt_set(_encoderContext->priv_data, "tune", "zerolatency", 0).ThrowExceptionIfError();
-                        break;
-                    default:
-                        break;
+                    // provide tunings for known codecs
+                    switch (cdcname)
+                    {
+                        case "libx264":
+                            ffmpeg.av_opt_set(_encoderContext->priv_data, "profile", "baseline", 0).ThrowExceptionIfError();
+                            ffmpeg.av_opt_set(_encoderContext->priv_data, "tune", "zerolatency", 0).ThrowExceptionIfError();
+                            break;
+                        case "h264_qsv":
+                            ffmpeg.av_opt_set(_encoderContext->priv_data, "profile", "66" /* baseline */, 0).ThrowExceptionIfError();
+                            ffmpeg.av_opt_set(_encoderContext->priv_data, "preset", "7" /* veryfast */, 0).ThrowExceptionIfError();
+                            break;
+                        case "libvpx":
+                            ffmpeg.av_opt_set(_encoderContext->priv_data, "quality", "realtime", 0).ThrowExceptionIfError();
+                            break;
+                        case "libx265":
+                            //ffmpeg.av_opt_set(_encoderContext->priv_data, "forced-idr", "1", 0).ThrowExceptionIfError();
+                            //ffmpeg.av_opt_set(_encoderContext->priv_data, "crf", "28", 0).ThrowExceptionIfError();
+                            ffmpeg.av_opt_set(_encoderContext->priv_data, "preset", "ultrafast", 0).ThrowExceptionIfError();
+                            ffmpeg.av_opt_set(_encoderContext->priv_data, "tune", "zerolatency", 0).ThrowExceptionIfError();
+                            break;
+                        default:
+                            break;
+                    }
                 }
-                    else if (_codecID == AVCodecID.AV_CODEC_ID_HEVC
-                        && Marshal.PtrToStringAnsi((IntPtr)codec->name) == "libx265")
-                    {
-                        //ffmpeg.av_opt_set(_encoderContext->priv_data, "forced-idr", "1", 0).ThrowExceptionIfError();
-
-                        //ffmpeg.av_opt_set(_encoderContext->priv_data, "crf", "28", 0);
-                        ffmpeg.av_opt_set(_encoderContext->priv_data, "preset", "ultrafast", 0).ThrowExceptionIfError();
-                        ffmpeg.av_opt_set(_encoderContext->priv_data, "tune", "zerolatency", 0).ThrowExceptionIfError();
-                    }
-
-                foreach (var option in _encoderOptions)
+                catch (ApplicationException ex)
                 {
-                    try
-                    {
-                        ffmpeg.av_opt_set(_encoderContext->priv_data, option.Key, option.Value, 0).ThrowExceptionIfError();
-                    }
-                    catch (Exception excp)
-                    {
-                        logger.LogWarning("Failed to set encoder option \"{key}\"=\"{val}\", Skipping this option. {msg}", option.Key, option.Value, excp.Message);
-                    }
-                };
+                    logger.LogCritical(ex, "Failed to set default encoder options for codec {name}. {msg}", cdcname, ex.Message);
+                    throw;
+                }
+
+                foreach (var option in _codecOptions)
+                {
+                    var ok = ffmpeg.av_opt_set(_encoderContext->priv_data, option.Key, option.Value, ffmpeg.AV_OPT_SEARCH_CHILDREN);
+                    if (ok < 0)
+                        logger.LogWarning("Failed to set encoder option \"{key}\"=\"{val}\", Skipping this option. {msg}", option.Key, option.Value, FFmpegInit.av_strerror(ok));
+                }
 
                 ffmpeg.avcodec_open2(_encoderContext, codec, null).ThrowExceptionIfError();
 
@@ -354,39 +350,8 @@ namespace SIPSorceryMedia.FFmpeg
                     {
                         ffmpeg.avcodec_free_context(pCtx);
                     }
-                }
-            }
-        }
 
-        private void ResetDecoder()
-        {
-            lock (_decoderLock)
-            {
-                if (!_isDisposed && _decoderContext != null && _isDecoderInitialised)
-                {
-                    _isDecoderInitialised = false;
-                    fixed (AVCodecContext** pCtx = &_decoderContext)
-                    {
-                        ffmpeg.avcodec_free_context(pCtx);
-                    }
-
-                    if (_frame != null)
-                    {
-                        fixed (AVFrame** pFrame = &_frame)
-                        {
-                            ffmpeg.av_frame_free(pFrame);
-                        }
-                    }
-
-                    if (_gpuFrame != null)
-                    {
-                        fixed (AVFrame** pFrame = &_gpuFrame)
-                        {
-                            ffmpeg.av_frame_free(pFrame);
-                    _negotiatedPixFmt = null;
-                }
-            }
-        }
+                    UnsafeReset();
                 }
             }
         }
@@ -403,8 +368,31 @@ namespace SIPSorceryMedia.FFmpeg
                     {
                         ffmpeg.avcodec_free_context(pCtx);
                     }
+                    
+                    UnsafeReset();
                 }
             }
+        }
+
+        private void UnsafeReset()
+        {
+            if (_frame != null)
+            {
+                fixed (AVFrame** pFrame = &_frame)
+                {
+                    ffmpeg.av_frame_free(pFrame);
+                }
+            }
+
+            if (_gpuFrame != null)
+            {
+                fixed (AVFrame** pFrame = &_gpuFrame)
+                {
+                    ffmpeg.av_frame_free(pFrame);
+                }
+            }
+
+            _negotiatedPixFmt = null;
         }
 
         private void InitialiseDecoder(AVCodecID codecID)

--- a/src/FFmpegVideoEncoder.cs
+++ b/src/FFmpegVideoEncoder.cs
@@ -283,7 +283,7 @@ namespace SIPSorceryMedia.FFmpeg
                         break;
                 }
                     else if (_codecID == AVCodecID.AV_CODEC_ID_HEVC
-                        && Marshal.PtrToStringAnsi((IntPtr)codec->name) == "hevc")
+                        && Marshal.PtrToStringAnsi((IntPtr)codec->name) == "libx265")
                     {
                         //ffmpeg.av_opt_set(_encoderContext->priv_data, "forced-idr", "1", 0).ThrowExceptionIfError();
 

--- a/src/FFmpegVideoEncoder.cs
+++ b/src/FFmpegVideoEncoder.cs
@@ -282,8 +282,17 @@ namespace SIPSorceryMedia.FFmpeg
                     default:
                         break;
                 }
+                    else if (_codecID == AVCodecID.AV_CODEC_ID_HEVC
+                        && Marshal.PtrToStringAnsi((IntPtr)codec->name) == "hevc")
+                    {
+                        //ffmpeg.av_opt_set(_encoderContext->priv_data, "forced-idr", "1", 0).ThrowExceptionIfError();
 
-                foreach (var option in encOpts)
+                        //ffmpeg.av_opt_set(_encoderContext->priv_data, "crf", "28", 0);
+                        ffmpeg.av_opt_set(_encoderContext->priv_data, "preset", "ultrafast", 0).ThrowExceptionIfError();
+                        ffmpeg.av_opt_set(_encoderContext->priv_data, "tune", "zerolatency", 0).ThrowExceptionIfError();
+                    }
+
+                foreach (var option in _encoderOptions)
                 {
                     try
                     {
@@ -331,7 +340,39 @@ namespace SIPSorceryMedia.FFmpeg
                     {
                         ffmpeg.avcodec_free_context(pCtx);
                     }
+                }
+            }
+        }
+
+        private void ResetDecoder()
+        {
+            lock (_decoderLock)
+            {
+                if (!_isDisposed && _decoderContext != null && _isDecoderInitialised)
+                {
+                    _isDecoderInitialised = false;
+                    fixed (AVCodecContext** pCtx = &_decoderContext)
+                    {
+                        ffmpeg.avcodec_free_context(pCtx);
+                    }
+
+                    if (_frame != null)
+                    {
+                        fixed (AVFrame** pFrame = &_frame)
+                        {
+                            ffmpeg.av_frame_free(pFrame);
+                        }
+                    }
+
+                    if (_gpuFrame != null)
+                    {
+                        fixed (AVFrame** pFrame = &_gpuFrame)
+                        {
+                            ffmpeg.av_frame_free(pFrame);
                     _negotiatedPixFmt = null;
+                }
+            }
+        }
                 }
             }
         }
@@ -663,6 +704,9 @@ namespace SIPSorceryMedia.FFmpeg
             {
                 width = 0;
                 height = 0;
+
+                if (_isDecoderInitialised && _codecID != codecID)
+                    ResetDecoder();
 
                 if (!_isDecoderInitialised)
                 {

--- a/src/FFmpegVideoEndPoint.cs
+++ b/src/FFmpegVideoEndPoint.cs
@@ -97,6 +97,20 @@ namespace SIPSorceryMedia.FFmpeg
         {
             if ( (!_isClosed) && (payload != null) && (OnVideoSinkDecodedSampleFaster != null) )
             {
+                if (_videoFormatManager.SelectedFormat.Codec != format.Codec)
+                {
+                    if (_videoFormatManager.GetSourceFormats().Exists(f => f.Codec == format.Codec))
+                    { 
+                        logger.LogWarning("Video format {format} is not selected but supported, continuing by using it.", format.FormatName);
+                        _videoFormatManager.SetSelectedFormat(format);
+                    }
+                    else
+                    {
+                        logger.LogError("Video format {format} is not supported by this endpoint.", format.FormatName);
+                        return;
+                    }
+                }
+
                 AVCodecID? codecID = FFmpegConvert.GetAVCodecID(_videoFormatManager.SelectedFormat.Codec);
                 if(codecID != null)
                 { 

--- a/src/FfmpegInit.cs
+++ b/src/FfmpegInit.cs
@@ -191,9 +191,21 @@ namespace SIPSorceryMedia.FFmpeg
                 case VideoCodecsEnum.VP8:
                     avCodecID = AVCodecID.AV_CODEC_ID_VP8;
                     break;
+                case VideoCodecsEnum.VP9:
+                    avCodecID = AVCodecID.AV_CODEC_ID_VP9;
+                    break;
                 case VideoCodecsEnum.H264:
                     avCodecID = AVCodecID.AV_CODEC_ID_H264;
                     break;
+                case VideoCodecsEnum.H265:
+                    avCodecID = AVCodecID.AV_CODEC_ID_HEVC;
+                    break;
+
+                // Currently disabled because MJPEG doesn't work with the current pipeline that forces pixel conversion to YUV420P
+                // TODO: Fix pixel format conversion in Decode->Encode pipeline
+                //case VideoCodecsEnum.JPEG:
+                //    avCodecID = AVCodecID.AV_CODEC_ID_MJPEG;
+                //    break;
             }
 
             return avCodecID;

--- a/src/Helper.cs
+++ b/src/Helper.cs
@@ -25,8 +25,8 @@ namespace SIPSorceryMedia.FFmpeg
         [
             new VideoFormat(VideoCodecsEnum.VP8, _dynFmtIdCounter++, VideoFormat.DEFAULT_CLOCK_RATE),
             new VideoFormat(VideoCodecsEnum.VP9, _dynFmtIdCounter++, VideoFormat.DEFAULT_CLOCK_RATE),
-            new VideoFormat(VideoCodecsEnum.H264, _dynFmtIdCounter++, VideoFormat.DEFAULT_CLOCK_RATE),
-            new VideoFormat(VideoCodecsEnum.H265, _dynFmtIdCounter++, VideoFormat.DEFAULT_CLOCK_RATE),
+            new VideoFormat(VideoCodecsEnum.H264, _dynFmtIdCounter++, VideoFormat.DEFAULT_CLOCK_RATE, "packetization-mode=1"),
+            new VideoFormat(VideoCodecsEnum.H265, _dynFmtIdCounter++, VideoFormat.DEFAULT_CLOCK_RATE, "packetization-mode=1"),
 
             // Currently disabled because MJPEG doesn't work with the current pipeline that forces pixel conversion to YUV420P
             // TODO: Fix pixel format conversion in Decode->Encode pipeline

--- a/src/Helper.cs
+++ b/src/Helper.cs
@@ -17,20 +17,16 @@ namespace SIPSorceryMedia.FFmpeg
         [Obsolete("H264 in RTP is defined as dynamic type, this may not be used for matching.")]
         public const int H264_FORMATID = 100;
 
-        const byte DYNAMIC_ID_MIN = 96;
-        const byte DYNAMIC_ID_MAX = 127;
-
-        private static readonly Random _dynamicFmtIdRand = new((int)DateTime.Now.Ticks + MIN_SLEEP_MILLISECONDS + DEFAULT_VIDEO_FRAME_RATE + VP8_FORMATID + H264_FORMATID);
+        private static int _dynFmtIdCounter = VideoFormat.DYNAMIC_ID_MIN;
 
         internal static List<VideoFormat> GetSupportedVideoFormats() => _supportedVidFormats; // Use predefined list of supported video formats
 
         private static readonly List<VideoFormat> _supportedVidFormats =
-
         [
-            new VideoFormat(VideoCodecsEnum.VP8, _dynamicFmtIdRand.Next(DYNAMIC_ID_MIN, DYNAMIC_ID_MAX), VideoFormat.DEFAULT_CLOCK_RATE),
-            new VideoFormat(VideoCodecsEnum.VP9, _dynamicFmtIdRand.Next(DYNAMIC_ID_MIN, DYNAMIC_ID_MAX), VideoFormat.DEFAULT_CLOCK_RATE),
-            new VideoFormat(VideoCodecsEnum.H264, _dynamicFmtIdRand.Next(DYNAMIC_ID_MIN, DYNAMIC_ID_MAX), VideoFormat.DEFAULT_CLOCK_RATE),
-            new VideoFormat(VideoCodecsEnum.H265, _dynamicFmtIdRand.Next(DYNAMIC_ID_MIN, DYNAMIC_ID_MAX), VideoFormat.DEFAULT_CLOCK_RATE),
+            new VideoFormat(VideoCodecsEnum.VP8, _dynFmtIdCounter++, VideoFormat.DEFAULT_CLOCK_RATE),
+            new VideoFormat(VideoCodecsEnum.VP9, _dynFmtIdCounter++, VideoFormat.DEFAULT_CLOCK_RATE),
+            new VideoFormat(VideoCodecsEnum.H264, _dynFmtIdCounter++, VideoFormat.DEFAULT_CLOCK_RATE),
+            new VideoFormat(VideoCodecsEnum.H265, _dynFmtIdCounter++, VideoFormat.DEFAULT_CLOCK_RATE),
 
             // Currently disabled because MJPEG doesn't work with the current pipeline that forces pixel conversion to YUV420P
             // TODO: Fix pixel format conversion in Decode->Encode pipeline

--- a/src/Helper.cs
+++ b/src/Helper.cs
@@ -11,13 +11,30 @@ namespace SIPSorceryMedia.FFmpeg
         public const int MIN_SLEEP_MILLISECONDS = 15;
         public const int DEFAULT_VIDEO_FRAME_RATE = 30;
 
+        // Old hardcoded
+        [Obsolete("VP8 in RTP is defined as dynamic type, this may not be used for matching.")]
         public const int VP8_FORMATID = 96;
+        [Obsolete("H264 in RTP is defined as dynamic type, this may not be used for matching.")]
         public const int H264_FORMATID = 100;
 
-        internal static List<VideoFormat> GetSupportedVideoFormats() => new List<VideoFormat>
-        {
-            new VideoFormat(VideoCodecsEnum.VP8, Helper.VP8_FORMATID, VideoFormat.DEFAULT_CLOCK_RATE),
-            new VideoFormat(VideoCodecsEnum.H264, Helper.H264_FORMATID, VideoFormat.DEFAULT_CLOCK_RATE)
-        };
+        const byte DYNAMIC_ID_MIN = 96;
+        const byte DYNAMIC_ID_MAX = 127;
+
+        private static readonly Random _dynamicFmtIdRand = new((int)DateTime.Now.Ticks + MIN_SLEEP_MILLISECONDS + DEFAULT_VIDEO_FRAME_RATE + VP8_FORMATID + H264_FORMATID);
+
+        internal static List<VideoFormat> GetSupportedVideoFormats() => _supportedVidFormats; // Use predefined list of supported video formats
+
+        private static readonly List<VideoFormat> _supportedVidFormats =
+
+        [
+            new VideoFormat(VideoCodecsEnum.VP8, _dynamicFmtIdRand.Next(DYNAMIC_ID_MIN, DYNAMIC_ID_MAX), VideoFormat.DEFAULT_CLOCK_RATE),
+            new VideoFormat(VideoCodecsEnum.VP9, _dynamicFmtIdRand.Next(DYNAMIC_ID_MIN, DYNAMIC_ID_MAX), VideoFormat.DEFAULT_CLOCK_RATE),
+            new VideoFormat(VideoCodecsEnum.H264, _dynamicFmtIdRand.Next(DYNAMIC_ID_MIN, DYNAMIC_ID_MAX), VideoFormat.DEFAULT_CLOCK_RATE),
+            new VideoFormat(VideoCodecsEnum.H265, _dynamicFmtIdRand.Next(DYNAMIC_ID_MIN, DYNAMIC_ID_MAX), VideoFormat.DEFAULT_CLOCK_RATE),
+
+            // Currently disabled because MJPEG doesn't work with the current pipeline that forces pixel conversion to YUV420P
+            // TODO: Fix pixel format conversion in Decode->Encode pipeline
+            //new VideoFormat(VideoCodecsEnum.JPEG, _dynamicFmtIdRand.Next(DYNAMIC_ID_MIN, DYNAMIC_ID_MAX), VideoFormat.DEFAULT_CLOCK_RATE),
+        ];
     }
 }


### PR DESCRIPTION
SIPSorcery supported H.265 packets via https://github.com/sipsorcery-org/sipsorcery/pull/1346

Improvements:
- [x] H.265/HEVC support with `libx265`,
- [x] Use dynamic RTP codecs ID counter,
- [x] Adds auto-detection of received video codec by supported formats.

**_(Fixed)_** <s>Quirks :
- For now only direct `IVideoSource`.`OnVideoSourceEncodedSample` to `IVideoSink`.`GotVideoFrame` will work flawlessly,
- <s>Only tested with SIPSorcery peers,</s> (nvm, not applicable)
- <s>**_only(?) I-frames (keyframes) are getting corrupted(?)._**</s></s>

<s>https://github.com/user-attachments/assets/5f098789-26d2-4702-9009-92af4f7ee765</s>

https://github.com/user-attachments/assets/0858f157-43cc-48e5-9adb-077e3d3d27cd
