### PR TITLE
Capability to specify Encoder by wrapper and name + Decoder-Encoder pixel format negotiation

### DIFF
--- a/src/FFmpegCameraManager.cs
+++ b/src/FFmpegCameraManager.cs
@@ -66,10 +66,16 @@ namespace SIPSorceryMedia.FFmpeg
     {
         public struct CameraFormat
         {
-            public AVPixelFormat PixelFormat;
-            public int Width;
-            public int Height;
-            public double FPS;
+            private int _pixFmt_;
+
+            public AVPixelFormat PixelFormat 
+            { 
+                get => (AVPixelFormat)_pixFmt_ - 1; 
+                set => _pixFmt_ = (int)value + 1;
+            }
+            public int Width { get; set; }
+            public int Height { get; set; }
+            public double FPS { get; set; }
         }
 
         public string Name { get; set; }

--- a/src/FFmpegCameraSource.cs
+++ b/src/FFmpegCameraSource.cs
@@ -184,14 +184,19 @@ namespace SIPSorceryMedia.FFmpeg
 
     internal static class FFmpegCameraExtensions
     {
-        internal static Dictionary<string, string> ToOptionDictionary(this Camera.CameraFormat c)
+        internal static Dictionary<string, string>? ToOptionDictionary(this Camera.CameraFormat c)
         {
+            if (c.Equals(default(Camera.CameraFormat))
+                || c.FPS == 0 || c.Width == 0 || c.Height == 0
+                )
+                return null;
+
             return new Dictionary<string, string>()
-                                {
-                                    { "pixel_format", ffmpeg.av_get_pix_fmt_name(c.PixelFormat) },
-                                    { "video_size", $"{c.Width}x{c.Height}" },
-                                    { "framerate", $"{c.FPS}" },
-                                };
+            {
+                { "pixel_format", ffmpeg.av_get_pix_fmt_name(c.PixelFormat) },
+                { "video_size", $"{c.Width}x{c.Height}" },
+                { "framerate", $"{c.FPS}" },
+            };
         }
 
     }

--- a/src/FFmpegFileSource.cs
+++ b/src/FFmpegFileSource.cs
@@ -302,5 +302,16 @@ namespace SIPSorceryMedia.FFmpeg
                 _FFmpegVideoSource = null;
             }
         }
+
+        public void SetEncoderWrapper(string v)
+        {
+            _FFmpegVideoSource?.SetEncoderWrapper(v);
+        }
+
+        public bool SetEncoderForCodec(VideoCodecsEnum codec, string name)
+        {
+            return _FFmpegVideoSource?.SetEncoderForCodec(codec, name) ?? false;
+        }
+
     }
 }

--- a/src/FFmpegVideoEncoder.cs
+++ b/src/FFmpegVideoEncoder.cs
@@ -166,7 +166,8 @@ namespace SIPSorceryMedia.FFmpeg
             var cdc = ffmpeg.av_codec_iterate((void**)&iterator);
             while (cdc != null)
             {
-                if (cdc->id == codecID && GetNameString(cdc->wrapper_name) == wrapName)
+                if (cdc->id == codecID && GetNameString(cdc->wrapper_name) == wrapName
+                    && ffmpeg.av_codec_is_encoder(cdc) != 0)
                     break;
 
                 cdc = ffmpeg.av_codec_iterate((void**)&iterator);

--- a/src/FFmpegVideoEncoder.cs
+++ b/src/FFmpegVideoEncoder.cs
@@ -642,7 +642,7 @@ namespace SIPSorceryMedia.FFmpeg
                             width, height,
                             (AVPixelFormat)decodedFrame->format,
                             width, height,
-                            AVPixelFormat.AV_PIX_FMT_BGR24);
+                            AVPixelFormat.AV_PIX_FMT_RGB24);
                     }
 
                     //logger.LogDebug($"[DecodeFaster]"

--- a/src/FFmpegVideoEndPoint.cs
+++ b/src/FFmpegVideoEndPoint.cs
@@ -70,7 +70,7 @@ namespace SIPSorceryMedia.FFmpeg
             else
             {
                 logger.LogError("Video Encoder is not yet initialized.");
-                throw new InvalidOperationException("Video Encoder is not yet initialized.");
+                throw new InvalidOperationException("Video Decoder is not yet initialized.");
             }
         }
 
@@ -89,7 +89,7 @@ namespace SIPSorceryMedia.FFmpeg
             else
             {
                 logger.LogError("Video Encoder is not yet initialized.");
-                throw new InvalidOperationException("Video Encoder is not yet initialized.");
+                throw new InvalidOperationException("Video Decoder is not yet initialized.");
             }
         }
 

--- a/src/FFmpegVideoSource.cs
+++ b/src/FFmpegVideoSource.cs
@@ -101,7 +101,40 @@ namespace SIPSorceryMedia.FFmpeg
             }
             else
             {
+                logger.LogError("Video Encoder is not yet initialized.");
                 throw new NullReferenceException("Video Encoder is not yet initialized.");
+            }
+        }
+
+        public void SetEncoderWrapper(string wrapperName)
+        {
+            if (_videoEncoder != null)
+            {
+                _videoEncoder.SetEncoderWrapper(wrapperName);
+            }
+            else
+            {
+                logger.LogError("Video Encoder is not yet initialized.");
+                throw new InvalidOperationException("Video Encoder is not yet initialized.");
+            }
+        }
+
+        public bool SetEncoderForCodec(VideoCodecsEnum codec, string name)
+        {
+            if (_videoEncoder != null)
+            {
+                if (FFmpegConvert.GetAVCodecID(codec) is var cdc && cdc is not null)
+                    return _videoEncoder.SetSpecificEncoderForCodec((AVCodecID)cdc, name);
+                else
+                {
+                    logger.LogError("Codec {codec} is not supported by this endpoint.", codec);
+                    throw new InvalidOperationException($"Codec {codec} is not supported by this endpoint.");
+                }
+            }
+            else
+            {
+                logger.LogError("Video Encoder is not yet initialized.");
+                throw new InvalidOperationException("Video Encoder is not yet initialized.");
             }
         }
 

--- a/src/FFmpegVideoSource.cs
+++ b/src/FFmpegVideoSource.cs
@@ -187,7 +187,7 @@ namespace SIPSorceryMedia.FFmpeg
                             paddedSrcWidth, height,
                             srcfmt,
                             width, height,
-                            AVPixelFormat.AV_PIX_FMT_BGR24);
+                            AVPixelFormat.AV_PIX_FMT_RGB24);
                         logger.LogDebug("Frame format: [{fmt}]", srcfmt);
                     }
 

--- a/src/FFmpegVideoSource.cs
+++ b/src/FFmpegVideoSource.cs
@@ -121,12 +121,12 @@ namespace SIPSorceryMedia.FFmpeg
             }
         }
 
-        public bool SetEncoderForCodec(VideoCodecsEnum codec, string name)
+        public bool SetEncoderForCodec(VideoCodecsEnum codec, string name, Dictionary<string, string>? opts = null)
         {
             if (_videoEncoder != null)
             {
                 if (FFmpegConvert.GetAVCodecID(codec) is var cdc && cdc is not null)
-                    return _videoEncoder.SetSpecificEncoderForCodec((AVCodecID)cdc, name);
+                    return _videoEncoder.SetSpecificEncoderForCodec((AVCodecID)cdc, name, opts);
                 else
                 {
                     logger.LogError("Codec {codec} is not supported by this endpoint.", codec);

--- a/src/FFmpegVideoSource.cs
+++ b/src/FFmpegVideoSource.cs
@@ -112,7 +112,7 @@ namespace SIPSorceryMedia.FFmpeg
         {
             if (_videoEncoder != null)
             {
-                _videoEncoder.SetEncoderWrapper(wrapperName);
+                _videoEncoder.SetCodec(wrapperName);
             }
             else
             {
@@ -126,7 +126,7 @@ namespace SIPSorceryMedia.FFmpeg
             if (_videoEncoder != null)
             {
                 if (FFmpegConvert.GetAVCodecID(codec) is var cdc && cdc is not null)
-                    return _videoEncoder.SetSpecificEncoderForCodec((AVCodecID)cdc, name, opts);
+                    return _videoEncoder.SetCodec((AVCodecID)cdc, name, opts);
                 else
                 {
                     logger.LogError("Codec {codec} is not supported by this endpoint.", codec);


### PR DESCRIPTION
# Main points:
## Specifying encoder for better utilization
- by wrapper (i.e. qsv, nvenc, amf, vaapi, etc.)
- by name (i.e. h264_qsv, hevc_nvenc, etc.)
- allowable per codec (i.e. H264, H265, VP8, VP9, etc.)
- tunings are now encoder-name-specific, fixes #66 
## Pixel format negotiation to prevent unnecessary pixel format conversion
- negotiate on the first time passing the decoded frame to the encoder,
#### DevNote:
- it works by restarting the decode-encode,
- override `OnNegotiatedPixelFormat` in the derived class if the decoder supports choosing pixel format.
## Minor fixes:
- fix force keyframe ignored #81 
- fixes the stride/linesize on RGB/BGR conversion for some reason #96 
- fix RGB BGR