### PR TITLE
Minor improvements for DirectShow camera

### DIFF
--- a/src/FFmpegCameraManager.cs
+++ b/src/FFmpegCameraManager.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
-using DirectShowLib;
 using System.Linq;
 
 namespace SIPSorceryMedia.FFmpeg

--- a/src/SIPSorceryMedia.FFmpeg.csproj
+++ b/src/SIPSorceryMedia.FFmpeg.csproj
@@ -13,9 +13,7 @@
   </PropertyGroup>
  
   <ItemGroup>
-    <PackageReference Include="DirectShowLib.Standard" Version="2.1.0" />
     <PackageReference Include="SIPSorceryMedia.Abstractions" Version="8.0.7" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="FFmpeg.AutoGen" Version="7.0.0" />
   </ItemGroup>
   


### PR DESCRIPTION
- caches cameras instead of querying everytime
- only query for not-seen-before cameras
- dereference DirectShowLib since `ffmpeg.avdevice_list_input_sources` implements the same underlying method.