### PR TITLE
Throw exception with helpful message on Initialize.

### DIFF
--- a/src/FfmpegInit.cs
+++ b/src/FfmpegInit.cs
@@ -96,7 +96,21 @@ namespace SIPSorceryMedia.FFmpeg
             ffmpeg.RootPath = path;
             registered = true;
 
-            ffmpeg.avdevice_register_all();
+            DynamicallyLoadedBindings.ThrowErrorIfFunctionNotFound = true;
+
+            try
+            {
+                ffmpeg.avdevice_register_all();
+            }
+            catch (Exception e)
+            {
+                throw new DllNotFoundException(
+                    "Check the dependencies of FFmpeg libraries and make sure they are " +
+                    "searchable by the operating system's library loader."
+                    + "\nOn linux you can use 'ldd' & 'strace'."
+                    + "\nOn Windows you can use 'Dependencies'."
+                    , e);
+            }
         }
 
         internal static void RegisterFFmpegBinaries(String? libPath = null)


### PR DESCRIPTION
This will help better diagnose what is wrong with the FFmpeg libraries rather than just empty Exception.

![image](https://github.com/user-attachments/assets/329a24a9-a29a-4673-b6b9-0c8b10560cba)

Though a better fix would be to provide FFmpeg static build script, thanks to this commit 569aa55c607f14cde6dfbe5376bb27df7235e6ed for the first step.

stales #91 #89 #72 #63
