### PR TITLE
video converter usage refactor

### DIFF
--- a/src/FFmpegVideoEncoder.cs
+++ b/src/FFmpegVideoEncoder.cs
@@ -721,15 +721,15 @@ namespace SIPSorceryMedia.FFmpeg
                     //    + $" - decode_error_flags:[{decodedFrame->decode_error_flags}]"
                     //    );
 
-                    var frameI420 = _i420ToRgb.Convert(*decodedFrame);
-                    if ((frameI420.width != 0) && (frameI420.height != 0))
+                    var frameI420 = _i420ToRgb.Convert(decodedFrame);
+                    if ((frameI420->width != 0) && (frameI420->height != 0))
                     {
                         RawImage imageRawSample = new RawImage
                         {
                             Width = width,
                             Height = height,
-                            Stride = frameI420.linesize[0],
-                            Sample = (IntPtr)frameI420.data[0],
+                            Stride = frameI420->linesize[0],
+                            Sample = (IntPtr)frameI420->data[0],
                             PixelFormat = VideoPixelFormatsEnum.Rgb
                         };
                         rgbFrames.Add(imageRawSample);


### PR DESCRIPTION
I forgot to include the refactor for `FFmpegVideoSource` and `FFmpegVideoEncoder` of the conversion in #101.

I answered in https://github.com/sipsorcery-org/SIPSorceryMedia.FFmpeg/pull/101#issuecomment-2779753346 by using this refactor, and it doesn't crash.
@sipsorcery does this cause test crashes?